### PR TITLE
Add Istio Bookinfo sample app

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 This repository will serve as a home for announcements of Managed Kubernetes on Azure (AKS) and communicating new features and [known issues](https://github.com/Azure/AKS/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3Aknown-issue) of the service.
 
 ## Announcements
-* **June 14, 2018** - [AKS is now GA](https://azure.microsoft.com/en-us/blog/azure-kubernetes-service-aks-ga-new-regions-new-features-new-productivity/)
 
 * **October 24, 2017** - [AKS Public Preview announced](https://azure.microsoft.com/en-us/blog/introducing-azure-container-service-aks-managed-kubernetes-and-azure-container-registry-geo-replication/)
 
@@ -17,9 +16,9 @@ This repository will serve as a home for announcements of Managed Kubernetes on 
 
 * **November 16, 2017** - Central US added to public preview
 
-* **January, 11, 2018** - Canada Central and Canada East added to public preview
+* **January 11, 2018** - Canada Central and Canada East added to public preview
 
-* **June, 13, 2018** - [GA announcement](https://azure.microsoft.com/en-us/blog/azure-kubernetes-service-aks-ga-new-regions-new-features-new-productivity/) with new regions: Australia East, UK South, West US, West US 2, and North Europe. Support for RBAC+AD integration.
+* **June 13, 2018** - [AKS is now GA.](https://azure.microsoft.com/en-us/blog/azure-kubernetes-service-aks-ga-new-regions-new-features-new-productivity/) New regions: Australia East, UK South, West US, West US 2, and North Europe. Support for RBAC+AD integration.
 
 ## Code of conduct
 

--- a/examples/simple_istio_app/README.md
+++ b/examples/simple_istio_app/README.md
@@ -1,0 +1,19 @@
+# Simple Istio app deployment on Azure AKS
+
+This bash script will mirror the Bookinfo app guide available on [Istio's site](https://istio.io/docs/guides/bookinfo/).
+
+For this script to work you must have:
+
+- An Azure account with a valid subscription
+- [Azure cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) installed on your path
+- [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed on your path
+- [Helm](https://docs.helm.sh/using_helm/#installing-helm) installed on your path
+
+Before running the script you have to populate the variables defined at the beginning (AZURE_SUBSCRIPTION_ID, LOCATION, etc).
+
+This script was tested on:
+- azure-cli (v2.0.42)
+- kubectl (v1.9.9)
+- helm (v2.9.1.)
+- istio (v0.8.0)
+

--- a/examples/simple_istio_app/deploy_bookinfo.sh
+++ b/examples/simple_istio_app/deploy_bookinfo.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -e
+
+# configurable
+AZURE_SUBSCRIPTION_ID= #guid format
+LOCATION=canadaeast #example location
+RESOURCE_GROUP_NAME=testIstioApp
+CLUSTER_NAME=testBookinfo
+
+ISTIO_VERSION=0.8.0 #changing the version might break the script
+
+echo ........ Logging into Azure
+az login
+az account set --subscription $AZURE_SUBSCRIPTION_ID
+echo ........
+
+echo ........ Creating resource group
+az group create -l $LOCATION -n $RESOURCE_GROUP_NAME
+echo ........
+
+echo ........ Creating AKS cluster
+az aks create --resource-group $RESOURCE_GROUP_NAME --name $CLUSTER_NAME --enable-rbac --node-count 4
+echo ........
+
+echo ........ Getting KubeConfig
+scriptDir="$( cd "$(dirname "$0")" ; pwd -P )"
+kubeConfigPath="$scriptDir/config"
+
+az aks get-credentials --resource-group $RESOURCE_GROUP_NAME --name $CLUSTER_NAME --file kubeConfigPath
+
+export KUBECONFIG=kubeConfigPath
+echo ........
+
+echo ........ Downloading Istio locally - **IGNORE instructions
+curl -L https://git.io/getIstio | sh -
+echo ........
+
+echo ........ Installing Helm
+kubectl apply -f istio-$ISTIO_VERSION/install/kubernetes/helm/helm-service-account.yaml
+helm init --service-account tiller --wait
+echo ........
+
+echo ........ Installing Istio - command might timeout but still work
+helm install --wait istio-$ISTIO_VERSION/install/kubernetes/helm/istio --name istio --namespace istio-system --debug --timeout 1000 --set global.tag=$ISTIO_VERSION || true
+echo ........
+
+echo ........ Waiting for Istio to be ready
+# wait logic until all pods are running
+n=0
+until [ $n -ge 20 ]
+do
+  kubectl get pods --namespace istio-system | tail -n +2 | awk '{ if ($3!="Running") exit 1}' && break
+  echo ........ Still waiting for Istio to be ready
+  n=$[$n+1]
+  sleep 30
+done
+echo ........
+
+echo ........ Deploying BookInfo app
+kubectl apply -f istio-$ISTIO_VERSION/samples/bookinfo/kube/bookinfo.yaml
+
+istio-$ISTIO_VERSION/bin/istioctl create -f istio-$ISTIO_VERSION/samples/bookinfo/routing/bookinfo-gateway.yaml
+
+# wait logic until all pods are running
+n=0
+until [ $n -ge 20 ]
+do
+  kubectl get pods | tail -n +2 | awk '{ if ($3!="Running") exit 1}' && break
+  echo ........ Still waiting for app deployment to be ready
+  n=$[$n+1]
+  sleep 30
+done
+echo ........
+
+echo ........ Testing BookInfo app response code
+ip="$(kubectl get svc --namespace istio-system | awk '{if ($1 ~ /^istio-ingressgateway/) print $4 }')"
+
+response_code="$(curl -o /dev/null -s -w "%{http_code}\n" http://${ip}/productpage)"
+
+if [ $response_code != "200" ]; then
+  echo Wrong response code, expecting 200
+  exit 1
+fi
+
+echo Done
+echo "Visit http://$ip/productpage"
+echo ........


### PR DESCRIPTION
This is a proposal to add another simple example, hopefully we can evolve the examples provided in this repo with time. 

For now there is some benefit to having this bash script that mirrors the guide provided by [Istio](https://istio.io/docs/guides/bookinfo/) which is missing small AKS deployment details. This will enable users to play around faster with AKS and other common deployments like Helm and Istio (which are included in this example).

Feel free to suggest any other approach or any feedback.