### PR TITLE
Updated Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Azure Kubernetes Service Changelog
 
-## Release 2019-04-04 - Hotfix (CVE-2019-1002101 mitigation)
+## Release 2019-04-04 - Hotfix (CVE-2019-9946 mitigation)
 **This release is currently rolling out to all regions**
 
 * New kubernetes versions released for CVE-2019-1002101  mitigation


### PR DESCRIPTION
Updated to point to correct hotfix for latest release

Changelog stated hotfix was for kubectl vulnerability, but the release should be for the following vulnerability CVE-2019-9946