### PR TITLE
Github Task automation PR

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,9 @@
+# Configuration for sentiment-bot - https://github.com/behaviorbot/sentiment-bot
+
+# *Required* toxicity threshold between 0 and .99 with the higher numbers being the most toxic
+# Anything higher than this threshold will be marked as toxic and commented on
+sentimentBotToxicityThreshold: .7
+
+# *Required* Comment to reply with
+sentimentBotReplyComment: >
+  Please be sure to review the [Code Of Conduct](https://opensource.microsoft.com/codeofconduct/) and be respectful of other users. cc/ @jnoller

--- a/.github/lock.yaml
+++ b/.github/lock.yaml
@@ -1,0 +1,21 @@
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 180
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: true
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: false

--- a/.github/lock.yaml
+++ b/.github/lock.yaml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 180
+daysUntilLock: 365
 
 # Skip issues and pull requests created before a given timestamp. Timestamp must
 # follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable

--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,0 +1,33 @@
+# Configuration for Move Issues - https://github.com/dessant/move-issues
+
+# Delete the command comment when it contains no other content
+deleteCommand: true
+
+# Close the source issue after moving
+closeSourceIssue: true
+
+# Lock the source issue after moving
+lockSourceIssue: false
+
+# Mention issue and comment authors
+mentionAuthors: true
+
+# Preserve mentions in the issue content
+keepContentMentions: false
+
+# Move labels that also exist on the target repository
+moveLabels: true
+
+# Set custom aliases for targets
+aliases:
+  r: engine
+  or: Azure/aks-engine
+  r: vk
+  or: virtual-kubelet/virtual-kubelet
+  r: cli
+  or: Azure/azure-cli
+  r: preview
+  or: Azure/azure-cli-extensions
+
+# Repository to extend settings from
+# _extends: repo

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 90
+daysUntilStale: 180
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,66 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - feature
+  - roadmap
+  - enhancement
+  - known-issue
+  - bug
+  - triage
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  activity in 90 days. It will be closed if no further activity occurs. Thank
+  you!
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
- Adds stale.yaml file for hosted https://github.com/probot/stale 
  - daysUntilStale: 90
  - daysUntilClose: 14
  - exempt tags listed in PR
- Adds lock.yaml file for hosted: https://probot.github.io/apps/lock/
  - Threads on closed issues will be locked after 90 days
- Adds move.yml for hosted https://probot.github.io/apps/move/
  - This allows maintainers to use the `/move to repo` and `/move to owner/repo` to move tickets for another project to that organization/repo (such as aks-engine issues, ACI, and VK)
  - Added a set of short-hand targets in pr
- Adds config.yaml for hosted https://github.com/apps/sentiment-bot
  - Toxic level set at .7 (non toxic)
  - Link to MS OSS Code of conduct, auto tag myself in marked thread

