### PR TITLE
[wip] node-exporter connector

### DIFF
--- a/examples/kube-prometheus/kustomization.yaml
+++ b/examples/kube-prometheus/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - github.com/prometheus-operator/kube-prometheus?ref=v0.9.0
 - coredns-prometheusRule.yaml
+- node-exporter-connector-daemonset.yaml
 
 patchesStrategicMerge:
 - alertmanager-secret.yaml

--- a/examples/kube-prometheus/node-exporter-connector-daemonset.yaml
+++ b/examples/kube-prometheus/node-exporter-connector-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+        image: mcr.microsoft.com/oss/kubernetes/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 19200

--- a/examples/kube-prometheus/nodeexporterconnectords.yaml
+++ b/examples/kube-prometheus/nodeexporterconnectords.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - args:
         - --logtostderr
-        - --secure-listen-address=[$(IP)]:9200
+        - --secure-listen-address=[$(IP)]:19200
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --upstream=http://[$(IP)]:19100/
         env:
@@ -28,7 +28,7 @@ spec:
         image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:
-        - containerPort: 9200
+        - containerPort: 19200
           name: https
         resources:
           limits:
@@ -61,7 +61,7 @@ spec:
   clusterIP: None
   ports:
   - name: https
-    port: 9200
+    port: 19100
     targetPort: https
   selector:
     app.kubernetes.io/name: node-exporter-connector

--- a/examples/kube-prometheus/nodeexporterconnectords.yaml
+++ b/examples/kube-prometheus/nodeexporterconnectords.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: node-exporter-connector
+  name: node-exporter-connector
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter-connector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-exporter-connector
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - --secure-listen-address=[$(IP)]:9200
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --upstream=http://[$(IP)]:19100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9200
+          name: https
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          runAsUser: 65532
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: node-exporter
+      tolerations:
+      - operator: Exists
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: node-exporter-connector
+  name: node-exporter-connector
+  namespace: monitoring
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 9200
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: node-exporter-connector
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: node-exporter-connector
+  name: node-exporter-connector
+  namespace: monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 30s
+    port: https
+    relabelings:
+    - sourceLabels:
+      - __metrics_path__
+      targetLabel: metrics_path
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - monitoring
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter-connector


### PR DESCRIPTION
Creating a PR now so I can share a way to scrape node-exporter on AKS node VM with kube-prometheus.

prometheus-operator needs there to be endpoints so it can use the 'endpoints' service discovery role for ServiceMonitors. For kubelet, it creates and reconciles [kubelet endpoints and service](http://github.com/prometheus-operator/prometheus-operator/blob/7f89c9aa0574a53bdf8f1ab979e49dab704919fe/pkg/prometheus/operator.go#L650-L725) instead of using the node service discovery role, so that's what the daemonset here is doing.

I still need to clean this up if I want to override the node-exporter k8s daemonset config.