### PR TITLE
update portal tags to use github team

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1898,9 +1898,7 @@
               "azure/portal"
             ],
             "mentionees": [
-              "jenetlan",
-              "chandraneel",
-              "raghulmsft"
+              "Azure/aks-portal"
             ]
           },
           {
@@ -2011,9 +2009,7 @@
               "client/portal"
             ],
             "mentionees": [
-              "jenetlan",
-              "chandraneel",
-              "raghulmsft"
+              "Azure/aks-portal"
             ]
           }
         ],


### PR DESCRIPTION
updated aks bot to use https://github.com/orgs/Azure/teams/aks-portal/ for tags related to Azure Portal, similar to https://github.com/orgs/Azure/teams/aks-leads and https://github.com/orgs/Azure/teams/aks-pm