### PR TITLE
Changing bot policies

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -83,7 +83,7 @@ configuration:
       - isNotAssigned
       actions:
       - addReply:
-          reply: Action required from @Azure/aks-pm
+          reply: Action required from @aritraghosh, @julia-yin, @AllenWen-at-Azure
       - addLabel:
           label: 'Needs Attention :wave:'
     - description: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -42,7 +42,7 @@ configuration:
       - addLabel:
           label: stale
       - addReply:
-          reply: This issue has been automatically marked as stale because it has not had any activity for **21 days**. It will be closed if no further activity occurs **within 15 days of this comment**.
+          reply: This issue has been automatically marked as stale because it has not had any activity for **21 days**. It will be closed if no further activity occurs **within 7 days of this comment**.
     - description: 
       frequencies:
       - hourly:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -31,7 +31,7 @@ configuration:
       - isIssue
       - isOpen
       - noActivitySince:
-          days: 60
+          days: 21
       - isNotLabeledWith:
           label: stale
       - isNotLabeledWith:
@@ -42,7 +42,7 @@ configuration:
       - addLabel:
           label: stale
       - addReply:
-          reply: This issue has been automatically marked as stale because it has not had any activity for **60 days**. It will be closed if no further activity occurs **within 15 days of this comment**.
+          reply: This issue has been automatically marked as stale because it has not had any activity for **21 days**. It will be closed if no further activity occurs **within 15 days of this comment**.
     - description: 
       frequencies:
       - hourly:


### PR DESCRIPTION
Changing policy to label as stale to 21 days: If an issue has been stale for more than 21 days, it gets labelled as stale
Assign to Allen, Aritra and Julia: For issues without a label, it is assigned to three of us to add the right label