### PR TITLE
Update broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ with AKS. For other tools, products and services see the [Upstream Azure Compute
 * AKS Community YouTube: <https://www.youtube.com/@theakscommunity>
 * AKS Public Community Channel: <https://twitter.com/theakscommunity>
 * Updates about the service, including new features and new Azure regions:
-  [AKS feed in Azure Updates](https://azure.microsoft.com/updates/?product=kubernetes-service)
+  [AKS RSS feed in Azure Updates](https://azurecomcdn.azureedge.net/updates/feed/?product=kubernetes-service)
 * AKS hybrid deployment options: <https://aka.ms/aks-hybrid>
 
 ## Code of conduct


### PR DESCRIPTION
**Proposed change:**
- The current link is broken, update with static RSS link: https://azurecomcdn.azureedge.net/updates/feed/?product=kubernetes-service

**Supporting points:**
1. The old link does break: ([link](https://azure.microsoft.com/updates/?product=kubernetes-service), [web archive](https://archive.is/cy6gx))
![image](https://github.com/Azure/AKS/assets/142381267/a88a6587-375f-488c-890a-13fb18fe178b)
2. The whole filter section was being removed from "Azure update" ([link](https://azure.microsoft.com/updates/), [web archive](https://archive.is/l5xap))
Before:
![image](https://github.com/Azure/AKS/assets/142381267/8f1632e4-1043-44ab-8bd5-3c3a2546435d)
After:
![image](https://github.com/Azure/AKS/assets/142381267/bad74dec-9314-4eee-bd0b-bbdb89c0ec67)
3. Based on point 1 and 2, it is suggested to change the link to static RSS feed link, so at least there is some valid where to go (Since the original link is to _Azure updates_, there is no alternative/substitution choice). The current link is working like below: ([link](https://azurecomcdn.azureedge.net/updates/feed/?product=kubernetes-service), [web archive](https://archive.is/TsHwB))
![image](https://github.com/Azure/AKS/assets/142381267/c1a609e8-b179-458a-aed7-3291ddf43182)
4. Prove if this is official domain and there is no harm: the domain is used in official Azure update page: `view-source:https://azure.microsoft.com/en-us/updates/`
![image](https://github.com/Azure/AKS/assets/142381267/12e5f462-f9bb-4d08-93d8-34d82489f291)


