### PR TITLE
Improve the bot in terms of labeling slate issue and closing issue etc.

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -291,6 +291,20 @@ configuration:
       - addReply:
           reply: Thanks for reaching out. I'm closing this issue as it was marked resolved and it hasn't had activity for 3 days. If it continues please reply or open a support ticket.
       - closeIssue
+    - description: 
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isOpen
+      - hasLabel:
+          label: resolution/code-merged
+      - noActivitySince:
+          days: 21
+      actions:
+      - addReply:
+          reply: Thanks for reaching out. I'm closing this issue as it was marked with "code merged" and it hasn't had activity for 21 days.
+      - closeIssue      
     eventResponderTasks:
     - if:
       - payloadType: Issue_Comment

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -38,6 +38,10 @@ configuration:
           label: feature-request
       - isNotLabeledWith:
           label: bug
+      - isNotLabeledWith:
+          label: enhancement
+      - isNotLabeledWith:
+          label: announcement
       actions:
       - addLabel:
           label: stale
@@ -248,6 +252,10 @@ configuration:
           days: 7
       - isNotLabeledWith:
           label: feature-request
+      - isNotLabeledWith:
+          label: enhancement
+      - isNotLabeledWith:
+          label: announcement
       - isNotLabeledWith:
           label: stale
       actions:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -291,7 +291,7 @@ configuration:
       - addReply:
           reply: Thanks for reaching out. I'm closing this issue as it was marked resolved and it hasn't had activity for 3 days. If it continues please reply or open a support ticket.
       - closeIssue
-    - description: 
+    - description: close the issue with code merged label without activities in 21 days.
       frequencies:
       - hourly:
           hour: 6
@@ -304,7 +304,20 @@ configuration:
       actions:
       - addReply:
           reply: Thanks for reaching out. I'm closing this issue as it was marked with "code merged" and it hasn't had activity for 21 days.
-      - closeIssue      
+      - closeIssue
+    - description: label issues with SLA warning if issues are not closed after 7 days.
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isOpen
+      - created:
+          before: 7
+      - hasLabel:
+          label: bug
+      actions:
+      - addLabel:
+          label: SLA
     eventResponderTasks:
     - if:
       - payloadType: Issue_Comment


### PR DESCRIPTION
3 changes to the bot in the PR

- Not to label "announcement" and "enhancement" issues as stale.
- Close issues having "resolution/code-merged" label without activities in 21 days.
- Label issues with "SLA" warning if issues are not closed in 7 days.