### PR TITLE
Added webinar folder and a page to view current and upcoming webinars

### DIFF
--- a/webinars/default.html
+++ b/webinars/default.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AKS Webinars</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: #f3f2f1;
+            color: #333;
+            margin: 0;
+            padding: 0;
+        }
+        .header {
+            background-color: #0078d4;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .container {
+            padding: 20px;
+            border-radius: 2px;
+            border-color: lightblue;
+        }
+        .webinar-details {
+            background-color: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            border-color: #8dc8e8;
+        }
+        .button {
+            display: inline-block;
+            padding: 10px 20px;
+            margin-top: 20px;
+            background-color: #0078d4;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+        }
+        .button:hover {
+            background-color: #005a9e;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>AKS Webinars</h1>
+    </div>
+    <div class="container">
+        <div class="webinar-details">
+            <h2>Upcoming Events</h2>
+            <ul>
+                <h3>AKS Feature Announcements from KubeCon & Ignite</h3>                
+                December 11, 2024 - 8 AM PST
+                <p>Join us for our first Azure Kubernetes Service (AKS) community call on December 11th at 8 AM Pacific time. We'll be reviewing all the exciting announcements and updates from KubeCon North America and Microsoft Ignite</p>
+                <p><a href="https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fmeetup-join%2F19%3Ameeting_ODY4NmY0Y2YtNTdhNi00YTcxLWFhOGQtMzk4ODdmMDc1MDY0%40thread.v2%2F0%3Fcontext%3D%257b%2522Tid%2522%253a%252272f988bf-86f1-41af-91ab-2d7cd011db47%2522%252c%2522Oid%2522%253a%2522e3e368ba-66aa-4e1b-86f6-63f9c1a9ac62%2522%257d%26anon%3Dtrue&type=meetup-join&deeplinkId=e6d24a15-5066-42dc-8b79-ff49c1062d55&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true">Join Now</a>&nbsp; <a href="">Add to my calendar</a></p>
+                
+                <strong>Presenters:</strong>
+                <ul>
+                    <li><strong>Jorge Palma:</strong>: Jorge is the Principal PM Lead for AKS (Azure Kubernetes Service) where he serves thousands of customers and mission critical application and helped lead the service to become the fastest growing service in Azure’s history. Formerly he was the Technical Lead for App Dev and DevOps with the Azure Global Black Belt team and has implemented and architected solutions in Azure since 2012, spanning across different roles from Services, Tech Evangelism and Tech Sales. He holds a MSc in Computer Engineering and has a mix of Dev and Ops background having worked as a full-stack developer before moving to a system administrator and later to a DevOps engineer role prior to joining Microsoft. He has founded two startups with successful exit throughout his career and has a passion for helping organizations and individuals grow and succeed leveraging the cloud and Kubernetes.</li>
+                </ul>
+            </ul>
+        </div>
+        <!-- <div class="webinar-details">
+            <h2>Past Events</h2>
+            <ul>
+                <li><strong>Event 1:</strong> October 5, 2023 - Introduction to Azure Functions</li>
+                <li><strong>Event 2:</strong> November 12, 2023 - Scaling Applications with AKS</li>
+                <li><strong>Event 3:</strong> December 1, 2023 - Monitoring and Logging in Azure</li>
+            </ul>
+        </div> -->
+    </div>
+</body>
+</html>


### PR DESCRIPTION
New folder "webinar"
New file - default.html - static html that lists all upcoming webinars and provides ability to join as well as add to calendar. 
We expect this to change frequently as new webinars get scheduled - with eventual automation. 