### PR TITLE
Updates to bug handling based on GitHub process review.

### DIFF
--- a/.github/policies/bugIssueLifecycleManagement.yml
+++ b/.github/policies/bugIssueLifecycleManagement.yml
@@ -8,7 +8,7 @@ where:
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:
-    - description: Stale any open bugs that have 30 days inactivity - runs every 6 hours
+    - description: Stale any open bugs that are not being investigated or fixed that have 30 days inactivity - runs every 6 hours
       frequencies:
       - hourly:
           hour: 6
@@ -17,18 +17,86 @@ configuration:
       - isOpen
       - noActivitySince:
           days: 30
-      - isNotLabeledWith:
-          label: stale
       - hasLabel:
           label: bug
+      - isNotLabeledWith:
+          label: stale
+      - isNotLabeledWith:
+          label: fixing
+      - isNotLabeledWith:
+          label: Under Investigation
+      actions:
+      - addLabel:
+          label: stale
+      - addReply:
+          reply: This issue has been automatically marked as stale because it has not had any activity for **30 days**. It will be closed if no further activity occurs **within 7 days of this comment**. Please review ${assignees}.
+    - description: Stale any open bugs that are not being investigated or fixed that have 30 days inactivity - runs every 6 hours
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isIssue
+      - isOpen
+      - noActivitySince:
+          days: 30
+      - hasLabel:
+          label: bug
+      - isNotLabeledWith:
+          label: stale
+      - isNotLabeledWith:
+          label: fixing
+      - isNotLabeledWith:
+          label: 'Under Investigation'
       actions:
       - addLabel:
           label: stale
       - addReply:
           reply: This issue has been automatically marked as stale because it has not had any activity for **30 days**. It will be closed if no further activity occurs **within 7 days of this comment**. ${assignees}
+    - description: Mark any bug labeled with 'Under Investigation' that is not waiting on Author Feedback with 'Needs Attention' after 14 days inactivity - runs every 6 hours
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isIssue
+      - isOpen
+      - hasLabel:
+          label: bug
+      - hasLabel:
+          label: 'Under Investigation'
+      - noActivitySince:
+          days: 14
+      - isNotLabeledWith:
+          label: Needs Author Feedback
+      actions:
+      - addLabel:
+          label: 'Needs Attention :wave:'
+      - addReply:
+          reply: This issue needs attention of ${assignees}. Please provide an update on the investigation progress. Thanks!
+    - description: Add reply and mention assignees on any bug labeled with 'Under Investigation' that is not waiting on Author Feedback which has been marked as 'Needs Attention' and had 7 days inactivity - runs every 6 hours
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isIssue
+      - isOpen
+      - hasLabel:
+          label: bug
+      - hasLabel:
+          label: 'Under Investigation'
+      - hasLabel:
+          label: 'Needs Attention :wave:'
+      - noActivitySince:
+          days: 7
+      - isNotLabeledWith:
+          label: Needs Author Feedback
+      actions:
+      - addReply:
+          reply: This issue needs attention of ${assignees}. Please provide an update on the investigation progress. Thanks! 
     eventResponderTasks:
-      - description: When an issue is labeled with 'SR-Support Request', add a reply with instructions on how to create a support ticket.
+      - description: When a bug is labeled with 'SR-Support Request', add a reply with instructions on how to create a support ticket.
         if:
+          - hasLabel:
+              label: bug
           - payloadType: Issues
           - labelAdded:
               label: SR-Support Request
@@ -48,7 +116,52 @@ configuration:
 
 
                 Thank you!
-      - description: If a new comment containing 'Released/Shipped/Fixed on release' is added to a bug', add the resolution labels. 
+      - description: When a bug is labeled with 'fixing', add a reply that notes the fix is under way and to expect updates when the fix is complete.
+        if:
+          - hasLabel:
+              label: bug
+          - payloadType: Issues
+          - labelAdded:
+              label: fixing
+          - isOpen
+        then:
+          - addReply:
+              reply: >-
+                Hi there :wave: AKS bot here. 
+
+                
+                Thank you for reporting this bug to the AKS team. 
+                
+
+                This issue has been tagged as 'fixing' as a bug fix is currently in progress. 
+                
+
+                When the fix is complete, we will update you with the investigation and fix details.
+
+
+                Thank you!
+      - description: When a bug is labeled with 'Under Investigation', add a reply that notes the investigation is under way and to check back later.
+        if:
+          - hasLabel:
+              label: bug
+          - payloadType: Issues
+          - labelAdded:
+              label: fixing
+          - isOpen
+        then:
+          - addReply:
+              reply: >-
+                Hi there :wave: AKS bot here. 
+            
+
+                This issue has been tagged as 'Under Investigation' by the AKS team. 
+                
+
+                Please check back shortly to see if any additional information or actions are needed from you.
+
+
+                Thank you!                
+      - description: If a new comment containing 'Released/Shipped/Fixed on release' is added to a bug, add the resolution labels. 
         if:
           - payloadType: Issue_Comment
           - isOpen


### PR DESCRIPTION
Based on request from team reviewing the process this PR contains the following changes:

1. When “Fix in Progress” (fixing) label is added to an issue labeled 'bug', send the following message: “Hi there :wave: AKS bot here. Thank you for reporting this bug to the AKS team. This issue has been tagged as the bug fix is currently in progress. When the fix is complete, we will update you with the investigation and fix details.” Do not mark issues with this label as Stale
2. When "Under Investigation" label is added to an issue labeled 'bug', send the following message: “Hi there :wave: AKS bot here. This issue has been tagged as being investigated by the AKS team. Please check back shortly to see if any additional information or actions are needed from you. Thank you!” Do not mark these issues as Stale.
3. For 'bug' issues with "Under Investigation" label, if there is no activity from assignees after 14 days then add the "Needs Attention" label. This will send out a message: “@assignees, this issue needs your attention. Please provide an update on the bug fix progress here. Thanks!” 
4. Keep sending out this message every 7days until the assignee responds, and when assignee responds remove the "Needs Attention" label.

