### PR TITLE
feat: add support for multiple authors

### DIFF
--- a/blog/_includes/author-profile.html
+++ b/blog/_includes/author-profile.html
@@ -1,0 +1,248 @@
+{% assign authors = page.authors | default: page.author %}
+
+{% for author_name in authors %}
+  {% assign author = site.data.authors[author_name] | default: author_name %} 
+
+  <div itemscope itemtype="https://schema.org/Person" class="h-card">
+    {% if author.avatar %}
+      <div class="author__avatar">
+        <a href="{{ author.home | default: '/' | absolute_url }}">
+          <img src="{{ author.avatar | relative_url }}" alt="{{ author.name }}" itemprop="image" class="u-photo">
+        </a>
+      </div>
+    {% endif %}
+
+    <div class="author__content">
+      <h3 class="author__name p-name" itemprop="name">
+        <a class="u-url" rel="me" href="{{ author.home | default: '/' | absolute_url }}" itemprop="url">{{ author.name }}</a>
+      </h3>
+      {% if author.bio %}
+        <div class="author__bio p-note" itemprop="description">
+          {{ author.bio | markdownify }}
+        </div>
+      {% endif %}
+    </div>
+
+    <div class="author__urls-wrapper">
+      <button class="btn btn--inverse">{{ site.data.ui-text[site.locale].follow_label | remove: ":" | default: "Follow" }}</button>
+      <ul class="author__urls social-icons">
+        {% if author.location %}
+          <li itemprop="homeLocation" itemscope itemtype="https://schema.org/Place">
+            <i class="fas fa-fw fa-map-marker-alt" aria-hidden="true"></i> <span itemprop="name" class="p-locality">{{ author.location }}</span>
+          </li>
+        {% endif %}
+
+        {% if author.links %}
+          {% for link in author.links %}
+            {% if link.label and link.url %}
+              <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer me"{% if link.url contains 'http' %} itemprop="sameAs"{% endif %}><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i><span class="label">{{ link.label }}</span></a></li>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+
+        {% if author.uri %}
+          <li>
+            <a href="{{ author.uri }}" itemprop="url" rel="me">
+              <i class="fas fa-fw fa-link" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[site.locale].website_label | default: "Website" }}</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.email %}
+          <li>
+            <a href="mailto:{{ author.email }}" rel="me" class="u-email">
+              <meta itemprop="email" content="{{ author.email }}" />
+              <i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.keybase %}
+          <li>
+            <a href="https://keybase.io/{{ author.keybase }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-keybase" aria-hidden="true"></i><span class="label">Keybase</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.twitter %}
+          <li>
+            <a href="https://twitter.com/{{ author.twitter }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-twitter-square" aria-hidden="true"></i><span class="label">Twitter</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.facebook %}
+          <li>
+            <a href="https://www.facebook.com/{{ author.facebook }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i><span class="label">Facebook</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.linkedin %}
+          <li>
+            <a href="https://www.linkedin.com/in/{{ author.linkedin }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-linkedin" aria-hidden="true"></i><span class="label">LinkedIn</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.xing %}
+          <li>
+            <a href="https://www.xing.com/profile/{{ author.xing }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-xing-square" aria-hidden="true"></i><span class="label">XING</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.instagram %}
+          <li>
+            <a href="https://instagram.com/{{ author.instagram }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-instagram" aria-hidden="true"></i><span class="label">Instagram</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.tumblr %}
+          <li>
+            <a href="https://{{ author.tumblr }}.tumblr.com" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-tumblr-square" aria-hidden="true"></i><span class="label">Tumblr</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.bitbucket %}
+          <li>
+            <a href="https://bitbucket.org/{{ author.bitbucket }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-bitbucket" aria-hidden="true"></i><span class="label">Bitbucket</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.github %}
+          <li>
+            <a href="https://github.com/{{ author.github }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-github" aria-hidden="true"></i><span class="label">GitHub</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.gitlab %}
+          <li>
+            <a href="https://gitlab.com/{{ author.gitlab }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-gitlab" aria-hidden="true"></i><span class="label">GitLab</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.stackoverflow %}
+          <li>
+            <a href="https://stackoverflow.com/users/{{ author.stackoverflow }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-stack-overflow" aria-hidden="true"></i><span class="label">Stack Overflow</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.lastfm %}
+          <li>
+            <a href="https://last.fm/user/{{ author.lastfm }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-lastfm-square" aria-hidden="true"></i><span class="label">Last.fm</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.dribbble %}
+          <li>
+            <a href="https://dribbble.com/{{ author.dribbble }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-dribbble" aria-hidden="true"></i><span class="label">Dribbble</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.pinterest %}
+          <li>
+            <a href="https://www.pinterest.com/{{ author.pinterest }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-pinterest" aria-hidden="true"></i><span class="label">Pinterest</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.foursquare %}
+          <li>
+            <a href="https://foursquare.com/{{ author.foursquare }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-foursquare" aria-hidden="true"></i><span class="label">Foursquare</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.steam %}
+          <li>
+            <a href="https://steamcommunity.com/id/{{ author.steam }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-steam" aria-hidden="true"></i><span class="label">Steam</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.youtube %}
+          {% if author.youtube contains "://" %}
+            <li>
+              <a href="{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+                <i class="fab fa-fw fa-youtube" aria-hidden="true"></i><span class="label">YouTube</span>
+              </a>
+            </li>
+          {% elsif author.youtube %}
+            <li>
+              <a href="https://www.youtube.com/user/{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+                <i class="fab fa-fw fa-youtube" aria-hidden="true"></i><span class="label">YouTube</span>
+              </a>
+            </li>
+          {% endif %}
+        {% endif %}
+
+        {% if author.soundcloud %}
+          <li>
+            <a href="https://soundcloud.com/{{ author.soundcloud }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-soundcloud" aria-hidden="true"></i><span class="label">SoundCloud</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.weibo %}
+          <li>
+            <a href="https://www.weibo.com/{{ author.weibo }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-weibo" aria-hidden="true"></i><span class="label">Weibo</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.flickr %}
+          <li>
+            <a href="https://www.flickr.com/{{ author.flickr }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-flickr" aria-hidden="true"></i><span class="label">Flickr</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.codepen %}
+          <li>
+            <a href="https://codepen.io/{{ author.codepen }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-codepen" aria-hidden="true"></i><span class="label">CodePen</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% if author.vine %}
+          <li>
+            <a href="https://vine.co/u/{{ author.vine }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
+              <i class="fab fa-fw fa-vine" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% include author-profile-custom-links.html %}
+      </ul>
+    </div>
+  </div>
+{% endfor %}

--- a/blog/_includes/page__meta.html
+++ b/blog/_includes/page__meta.html
@@ -1,4 +1,5 @@
 {% assign document = post | default: page %}
+{% assign author_count = document.authors | size %}
 
 <div class="page__meta-description">{{ document.description }}</div>
 {% if document.read_time or document.show_date %}
@@ -19,7 +20,28 @@
       {% assign words = document.content | strip_html | number_of_words %}
 
       <span class="page__meta-readtime">
-        Posted by {{ document.author }}&nbsp;&nbsp;<i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ document.date | date: "%B %-d, %Y" }}&nbsp;&nbsp;
+        Posted by
+        
+        {% if author_count == 0 %}
+            {{ document.author }}
+        {% elsif author_count == 1 %}
+            {{ document.authors | first }}
+        {% else %}
+            {% for author in document.authors %}
+                {% if forloop.first and author_count == 2 %}
+                    {{ author }}
+                {% elsif forloop.first and author_count > 2 %}
+                    {{ author }},
+                {% elsif forloop.last %}
+                    and {{ author }}
+                {% else %}
+                    {{ author }}, 
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+        
+        &nbsp;&nbsp;<i class="fas fa-fw fa-calendar-alt" aria-hidden="true"></i> {{ document.date | date: "%B %-d, %Y" }}&nbsp;&nbsp;
+        
         <i class="far {% if include.type == 'grid' and document.read_time and document.show_date %}fa-fw {% endif %}fa-clock" aria-hidden="true"></i>&nbsp;
         {% if words < words_per_minute %}
           {{ site.data.ui-text[site.locale].less_than | default: "less than" }} 1 {{ site.data.ui-text[site.locale].minute_read | default: "minute read" }}

--- a/blog/_posts/2025-01-30-kube-resource-orchestrator.md
+++ b/blog/_posts/2025-01-30-kube-resource-orchestrator.md
@@ -3,7 +3,9 @@ title: "Building Community with CRDs: Kube Resource Orchestrator"
 description: "Kube Resource Orchestrator (kro) streamlines Kubernetes complexity."
 date: 2025-01-30
 author: Bridget Kromhout
-categories: operations, developer topics
+categories: 
+- operations
+- developer
 ---
 
 _Authored by_ [Matthew Christopher](https://github.com/matthchr) & Bridget Kromhout

--- a/blog/_posts/2050-08-24-sample-blog-post.md
+++ b/blog/_posts/2050-08-24-sample-blog-post.md
@@ -3,7 +3,14 @@ title: "Sample - Add your title here"
 description: "Sample - Add your description"
 date: 2050-08-24 # date is important. future dates will not be published
 author: Brian Redmond # must match the authors.yml in the _data folder
-categories: general # general, operations, networking, security, developer topics, add-ons
+categories: 
+- general 
+# - general
+# - operations
+# - networking
+# - security
+# - developer
+# - add-ons
 ---
 
 ## Background


### PR DESCRIPTION
When creating a blog post with multiple authors you can now use the `authors` front matter element like this

```yaml
---
authors: 
- Author One
- Author Two 
---
```

This will work for single or multiple post authors. The original `author` front matter element for single-author posts will continue to work as well.