### PR TITLE
Correcting date

### DIFF
--- a/website/blog/2025-08-04-core-extension/index.md
+++ b/website/blog/2025-08-04-core-extension/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Introducing Core Kubernetes Extensions for AKS"
-date: "2024-08-04"
+date: "2025-08-04"
 description: "Learn what core Kubernetes extensions are, and how they can extend the functionality of your AKS clusters"
 authors: ["jane-guo"]
 tags:


### PR DESCRIPTION
The blog migration uncovered a discrepancy between a filename and the date string in the file.

Looking at https://github.com/MicrosoftDocs/azure-aks-docs/blob/main/articles/aks/cluster-extensions.md it does seem to be the case that the filename was in error. The feature went GA in 2025, and the blog post author @janeziqiguo confirms the 2025 date.