### PR TITLE
fix(website): update Jack Ma author avatar URL

### DIFF
--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -414,7 +414,7 @@ jack-ma:
   name: Jack Ma
   title: Principal Software Engineer at Microsoft
   url: https://www.linkedin.com/in/jack4it
-  image_url: https://media.licdn.com/dms/image/v2/D5603AQHWwAMPN6xj4w/profile-displayphoto-scale_200_200/B56ZlTcSj3G4AY-/0/1758041549408?e=1765411200&v=beta&t=cdJXzpnYartjuhqMlvhay18El6rlGu2VfNK4xGdviss
+  image_url: https://avatars.githubusercontent.com/u/3120462?s=400&u=19b5d6c8c8c536874771373ed92ba73f404e8ca1&v=4
   socials:
     x: jack4it
     linkedin: jack4it


### PR DESCRIPTION
## Summary

Updates the author avatar image URL for Jack Ma in the blog authors configuration.

## Changes

- Replaced LinkedIn profile photo URL with GitHub avatar URL for more reliable image hosting