### PR TITLE
Update CHANGELOG with new service tags feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ For deprecation, rollouts and patch timelines by region, please check the [AKS-R
   - A ValidatingAdmissionPolicy (VAP) restricts creation or updates of ClusterRole and Role objects granting `nodes/proxy`, except for approved system users and groups.
   - An authorization policy denies `nodes/proxy` by default. Approved system users, groups, and kube-system service accounts are exempt.
 * On clusters where ACNS performance is used to enable [eBPF host routing](https://learn.microsoft.com/azure/aks/how-to-enable-ebpf-host-routing), nodes will be labeled with `kubernetes.azure.com/ebpf-host-routing=true`. This is done by a node image upgrade.
-* [Service tags for API server authorized IP ranges](https://learn.microsoft.com/azure/aks/api-server-service-tags) now support AKS clusters with API Server VNet Integration.
+* [Service tags for API server authorized IP ranges](https://learn.microsoft.com/azure/aks/api-server-service-tags) are now supported for AKS clusters with API server VNet integration.
 
 ### Component Updates
 * Cilium has been updated from v1.18.2 to [v1.18.6](https://github.com/cilium/cilium/releases/tag/v1.18.6) to address CVEs: [CVE-2025-64715](https://nvd.nist.gov/vuln/detail/CVE-2025-64715) and [CVE-2026-26963](https://nvd.nist.gov/vuln/detail/CVE-2026-26963).


### PR DESCRIPTION
Added support for service tags in API server authorized IP ranges for AKS clusters with VNet Integration.