### PR TITLE
blog: remove duplication and trim prose across AI inference series

### DIFF
--- a/website/blog/2026-04-07-ai-inference-on-aks-arc-part-1/index.md
+++ b/website/blog/2026-04-07-ai-inference-on-aks-arc-part-1/index.md
@@ -18,42 +18,15 @@ Whether you are processing sensor data on a factory floor, analyzing medical ima
 
 ## Why AI inferencing on AKS enabled by Azure Arc matters
 
-Running AI inference on AKS enabled by Azure Arc addresses several urgent customer needs and industry trends:
-
-- **Low latency and data residency –**
-Inference workloads can run locally on-premises or at the edge, ensuring real-time responsiveness and compliance with data sovereignty requirements. This is essential for scenarios like factory automation, medical imaging, or retail analytics, where data must remain on-site and latency is a key constraint.
-
-- **Existing hardware utilization –**
-This lets you use existing infrastructure while keeping the flexibility to scale with GPUs or other accelerators later.
-
-- **Hybrid and disconnected operations –**
-AKS enabled by Azure Arc provides a consistent deployment and governance experience across connected and disconnected environments. Customers can centrally manage AI workloads from Azure while ensuring local execution continues even during network outages.
-
-- **Aligned with industry trends –**
-The shift toward hybrid and edge AI is driven by trends like data gravity, regulatory compliance, and the need for real-time insights. AKS enabled by Azure Arc aligns with these trends by enabling scalable, secure, and flexible AI deployments across industries such as manufacturing, healthcare, retail, and logistics.
+- **Low latency and data residency:** Inference runs locally, meeting real-time and compliance requirements for factory automation, medical imaging, and retail analytics.
+- **Existing hardware utilization:** Use your current infrastructure with flexibility to add GPUs or accelerators later.
+- **Hybrid and disconnected operations:** Manage workloads centrally from Azure while local execution continues during network outages.
+- **Industry alignment:** Support the shift toward edge AI driven by data gravity, regulatory compliance, and real-time requirements.
 
 ## A platform for distributed AI operations
 
-AKS enabled by Azure Arc enables you to bring your own AI runtimes and models to Kubernetes clusters running in hybrid environments. It provides:
-
-- A consistent DevOps experience for deploying and managing AI models across environments
-- Centralized governance, monitoring, and security via Azure
-- Integration with Azure ML and Microsoft Foundry for model lifecycle management
-- Support for diverse hardware configurations, including CPUs, GPUs, and NPUs
-
-By managing Kubernetes clusters across hybrid and edge environments, AKS enabled by Azure Arc helps you operationalize AI workloads using the tools and runtimes that best fit your infrastructure and use cases.
-
-## Explore AI inference with step-by-step tutorials
-
-To help you explore and validate AI inference on AKS enabled by Azure Arc, we’ve created a series of scenario-driven tutorials that show how to run both generative and predictive workloads in hybrid and edge environments. The series walks through concrete examples step by step, using open-source tools and real models to demonstrate hybrid AI capabilities in action. Each tutorial highlights a different inference pattern and technology stack, reflecting the diverse options available for edge inferencing:
-
-- Deploy open-source large language models (LLMs) using GPU-accelerated inference engines
-- Serve predictive models like ResNet-50 using a unified model server
-- Configure and validate inference workloads across different hardware types
-- Manage and monitor inference services using Azure-native tools
-
-These tutorials help you build confidence running AI at the edge using your existing Kubernetes skills and AKS enabled by Azure Arc infrastructure. The examples rely on off the shelf assets such as open source models and containers to highlight an open and flexible approach. You can bring your own models and select the inference engine best suited to the task whether that is a lightweight CPU friendly runtime or a vendor optimized GPU server.
+AKS enabled by Azure Arc enables you to bring your own AI runtimes and models to Kubernetes clusters running in hybrid environments. It provides a consistent DevOps experience, centralized governance via Azure, integration with Azure ML and Microsoft Foundry, and support for CPUs, GPUs, and NPUs so you can operationalize AI workloads using the tools that best fit your infrastructure.
 
 ## Get started
 
-To get started, follow the tutorial series: [AI Inference on AKS Arc: Series Introduction and Scope](/2026/04/07/ai-inference-on-aks-arc-part-2). By the end, you'll have hands-on experience running AI models across hybrid cloud and edge environments on Azure Arc.
+This series walks you through deploying generative and predictive AI workloads step by step, using open-source tools and real models on your AKS enabled by Azure Arc clusters. For the full list of topics, prerequisites, and hands-on tutorials, head to the [Series Introduction and Scope](/2026/04/07/ai-inference-on-aks-arc-part-2).

--- a/website/blog/2026-04-07-ai-inference-on-aks-arc-part-2/index.md
+++ b/website/blog/2026-04-07-ai-inference-on-aks-arc-part-2/index.md
@@ -14,89 +14,36 @@ This series gives you **practical, step-by-step guidance** for running generativ
 
 ## Introduction
 
-This series explores emerging patterns for running generative and predictive AI inference workloads on AKS enabled by Azure Arc clusters in on-premises and edge environments. If you're looking to deploy AI closer to where your data is generated on factory floors, in retail stores, across manufacturing lines, and within infrastructure monitoring systems—they face unique challenges: limited connectivity, diverse hardware, and constrained resources.
-High-end GPUs may not always be available or practical in these environments due to cost, power, or space limitations. That's why you may be exploring how to leverage your existing infrastructure—such as CPU-based clusters—or exploring new accelerators like NPUs to enable scalable, low-latency inference at the edge.
-The series focuses on scenario-driven experimentation with AI inference on AKS enabled by Azure Arc, validating real-world deployments that go beyond traditional cloud-centric patterns. From deploying open-source LLM servers like **Ollama** and **vLLM** to integrating **NVIDIA Triton** with custom backends, each entry provides a structured approach to evaluating feasibility, performance, and operational readiness. Our goal is to equip you with practical insights and repeatable strategies for enabling AI inference in hybrid and edge-native environments.
+[Part 1](/2026/04/07/ai-inference-on-aks-arc-part-1) covered why running AI inference at the edge matters. This post defines the series scope, ground rules, and shared prerequisites so each tutorial can focus on the hands-on deployment.
 
-## Audience and assumptions
+## Scope and ground rules
 
-This series assumes:
+This series assumes you are familiar with Kubernetes (pods, deployments, services, node scheduling), comfortable with kubectl, Azure CLI, and Helm, and operating or planning to operate AKS enabled by Azure Arc on Azure Local or a comparable environment. The focus is infrastructure and platform validation, not data science or model training.
 
-- You are already familiar with Kubernetes concepts such as pods, deployments, services, and node scheduling.
-- You are operating, or plan to operate, AKS enabled by Azure Arc on Azure Local or a comparable on‑premises / edge environment.
-- You are comfortable using command‑line tools such as kubectl, Azure CLI, and Helm.
-- You are evaluating AI inference workloads (LLMs or predictive models) from an infrastructure and platform perspective, not from a data science or model‑training perspective.
+**Not covered:**
 
-### Explicit Non‑Goals
+- [Kubernetes fundamentals](https://learn.microsoft.com/training/modules/intro-to-kubernetes/)
+- [AKS enabled by Azure Arc overview](https://learn.microsoft.com/azure/azure-arc/kubernetes/overview)
+- [AKS enabled by Azure Arc documentation](https://learn.microsoft.com/azure/aks/aksarc/)
+- Model training and fine-tuning
+- [Triton Inference Server internals](https://docs.nvidia.com/deeplearning/triton-inference-server/)
+- [GPU Operator internals](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html)
 
-To keep this series focused and actionable, the following topics are intentionally **not** covered:
-
-- **Kubernetes fundamentals or onboarding:**
-  Readers new to Kubernetes should complete foundational material first:
-  - [Introduction to Kubernetes (Microsoft Learn)](https://learn.microsoft.com/training/modules/intro-to-kubernetes/)
-  - [Kubernetes Basics Tutorial (Upstream)](https://kubernetes.io/docs/tutorials/kubernetes-basics/)
-
-- **AKS enabled by Azure Arc conceptual overview or onboarding:**
-  This series assumes you already understand what Azure Arc provides and how AKS enabled by Azure Arc works:
-  - [AKS enabled by Azure Arc Kubernetes overview](https://learn.microsoft.com/azure/azure-arc/kubernetes/overview)
-  - [AKS enabled by Azure Arc documentation](https://learn.microsoft.com/azure/aks/aksarc/)
-
-- **Model training, fine‑tuning, or data preparation:**
-  All scenarios assume models are already trained and packaged in formats supported by the selected inference engine.
-
-- **Deep internals of inference engines:**
-  Engine-specific internals are referenced only where required for deployment or configuration. For deeper learning:
-  - [NVIDIA Triton Inference Server documentation](https://docs.nvidia.com/deeplearning/triton-inference-server/)
-  - [NVIDIA GPU Operator documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html)
-
-If you’re looking for conceptual comparisons, performance benchmarks, or model‑level optimizations, those topics are intentionally out of scope for this series.
-
-## Series ground rules (What this series guarantees)
-
-Here are the set of baseline guarantees and assumptions that apply to all subsequent parts of the series:
-
-- All scenarios use the same AKS enabled by Azure Arc environment unless explicitly noted otherwise.
-- AKS enabled by Azure Arc is used as the management and control plane only; inference execution always occurs locally on the cluster.
-- No managed Azure AI services are used to execute inference.
-- Each scenario follows a consistent, repeatable structure so results can be compared across inference engines and hardware types.
-
-### Standard workflow
-
-Each scenario follows the same high-level workflow:
-
-- **Connect and verify:**
-  Log in to Azure and get cluster credentials. Inspect available compute resources (CPU, GPU, NPU) and node labels/capabilities
-
-- **Prepare the accelerator (If Required):**
-  Install or validate the required accelerator enablement based on the scenario.
-  - GPU: NVIDIA GPU Operator
-  - NPU: Vendor‑specific enablement (future)
-  - CPU: No accelerator setup required
-- **Deploy the inference Workload:**
-  - Deploy the model server or inference pipeline (LLM server, Triton, or other engine)
-  - Configure runtime parameters appropriate to the selected hardware
-- **Validate inference:**
-  - Send a test request (prompt, image, or payload)
-  - Confirm functional and expected inference output
-- **Cleanup resources:**
-  - Remove deployed workloads
-  - Release cluster resources (compute, storage, accelerator allocations)
+**Ground rules:** All scenarios use the same AKS enabled by Azure Arc environment and follow a consistent structure. Inference execution always occurs locally on the cluster. No managed Azure AI services are used. Each scenario follows the same steps: **connect and verify** cluster access, **prepare the accelerator** if required, **deploy the inference workload**, **validate inference** with a test request, and **clean up resources**.
 
 ## Series outline
 
-In this series, we walk you through a range of AI inference patterns on AKS enabled by Azure Arc clusters, spanning both generative and predictive AI workloads. The series is designed to evolve over time, and we'll continue adding topics as we validate new scenarios, runtimes, and architectures.
+The series is designed to evolve. New topics will be added as additional scenarios, runtimes, and architectures are validated.
 
 ### Topics covered in this series
 
 | Topic | Type | Status |
 | ----- | ---- | ------ |
-| [**Ollama** — open-source LLM server](/2026/04/07/ai-inference-on-aks-arc-part-3) | Generative | ✅ Available |
-| [**vLLM** — high-throughput LLM engine](/2026/04/07/ai-inference-on-aks-arc-part-3) | Generative | ✅ Available |
-| [**Triton + ONNX** — ResNet‑50 image classification](/2026/04/07/ai-inference-on-aks-arc-part-4) | Predictive | ✅ Available |
-| **Triton + TensorRT‑LLM** — optimized large-model inference | Generative | 🔜 Coming soon |
-| **Triton + vLLM backend** — vision-language model serving | Generative | 🔜 Coming soon |
-
-This series will continue to grow as we introduce new inference engines, hardware configurations, and real‑world deployment patterns across edge, on‑premises, and hybrid environments.
+| [**Ollama**: open-source LLM server](/2026/04/07/ai-inference-on-aks-arc-part-3) | Generative | ✅ Available |
+| [**vLLM**: high-throughput LLM engine](/2026/04/07/ai-inference-on-aks-arc-part-3) | Generative | ✅ Available |
+| [**Triton + ONNX**: ResNet‑50 image classification](/2026/04/07/ai-inference-on-aks-arc-part-4) | Predictive | ✅ Available |
+| **Triton + TensorRT‑LLM**: optimized large-model inference | Generative | 🔜 Coming soon |
+| **Triton + vLLM backend**: vision-language model serving | Generative | 🔜 Coming soon |
 
 ## Prerequisites
 

--- a/website/blog/2026-04-07-ai-inference-on-aks-arc-part-3/index.md
+++ b/website/blog/2026-04-07-ai-inference-on-aks-arc-part-3/index.md
@@ -7,7 +7,7 @@ authors:
 tags: ["aks-arc", "ai", "ai-inference"]
 ---
 
-In this post, you'll explore how to deploy and run generative AI inference workloads using open-source large language model servers on Azure Kubernetes Service (AKS) enabled by Azure Arc. You'll focus on running these workloads locally, on-premises or at the edge, using GPU acceleration with centralized management. This approach is especially useful when cloud-based AI services are not viable due to data sovereignty, latency, cost, or limited connectivity.
+In this post, you'll explore how to deploy and run generative AI inference workloads using open-source large language model servers on Azure Kubernetes Service (AKS) enabled by Azure Arc. You'll focus on running these workloads locally, on-premises or at the edge, using GPU acceleration with centralized management.
 
 <!-- truncate -->
 
@@ -15,21 +15,19 @@ In this post, you'll explore how to deploy and run generative AI inference workl
 
 ## Introduction
 
-Rather than using managed AI services, you'll deploy Ollama and vLLM as standalone Kubernetes workloads directly on your cluster. This keeps things transparent — you'll see exactly how model serving, GPU scheduling, and inference requests work inside your Arc-managed environment. Performance tuning and benchmarks are out of scope here; the focus is a clear, repeatable, and diagnosable foundation for GPU-accelerated inference. These fundamentals set you up for the more advanced architectures covered in later posts.
+Rather than using managed AI services, you'll deploy Ollama and vLLM as standalone Kubernetes workloads directly on your cluster. This keeps things transparent. You'll see exactly how model serving, GPU scheduling, and inference requests work inside your Arc-managed environment. Performance tuning and benchmarks are out of scope here; the focus is a clear, repeatable, and diagnosable foundation for GPU-accelerated inference. These fundamentals set you up for the more advanced architectures covered in later posts.
 
 :::note
-Before you begin, ensure the prerequisites described in [AI Inference on AKS enabled by Azure Arc: Series Introduction and Scope](/2026/04/07/ai-inference-on-aks-arc-part-2) are fully met.
-You should have an AKS enabled by Azure Arc cluster (on Azure Local or similar) with a **GPU node** available and configured for **nvidia.com/gpu**.
-The cluster nodes must have **internet access** to download the model. If restricted, you must manually provide the model files via a Persistent Volume. **Expect a delay** during the initial deployment while the **pod downloads** and caches the large model files.
+Before you begin, ensure the [Part 2 prerequisites](/2026/04/07/ai-inference-on-aks-arc-part-2) are met, including a GPU node configured for **nvidia.com/gpu**. Cluster nodes need **internet access** to download models. **Expect a delay** during initial deployment while the pod downloads and caches model files.
 :::
 
 ## AI inference with Ollama
 
-Now that your environment is ready, you'll deploy the Ollama model server. You'll use Ollama's official container image to serve a large language model — specifically **Phi-3 Mini** with 4-bit quantization (~2.2 GB), which fits comfortably on a single **16 GB GPU**. Once deployed, you'll have a single endpoint that supports both Ollama's native REST API and an OpenAI-compatible interface.
+Now that your environment is ready, you'll deploy the Ollama model server. You'll use Ollama's official container image to serve a large language model, specifically **Phi-3 Mini** with 4-bit quantization (~2.2 GB), which fits comfortably on a single **16 GB GPU**. Once deployed, you'll have a single endpoint that supports both Ollama's native REST API and an OpenAI-compatible interface.
 
 ### Deploying the Ollama model server
 
-First, ensure you have connected to your Arc-enabled cluster (see Prerequisites) and that it has a GPU node with the NVIDIA device plugin ready (the GPU Operator should be installed). If your cluster has multiple GPU nodes, apply the accelerator=nvidia-gpu label to a node to ensure the Ollama pod schedules on your target hardware.
+If your cluster has multiple GPU nodes, apply the `accelerator=nvidia-gpu` label to a node to ensure the Ollama pod schedules on your target hardware.
 
 ```powershell
 # 1. FIND THE GPU NODE NAME
@@ -126,7 +124,7 @@ spec:
     targetPort: 11434  # The port the Ollama application is listening on inside the pod.
 ```
 
-This defines a **Deployment** running one instance of the ollama/ollama:0.18.3 container image, exposing the server on port **11434**, and requesting 1 GPU (nvidia.com/gpu: 1) so it runs on your GPU node. A LoadBalancer Service on port 11434 forwards requests to the pod; on Azure Local, if no external load balancer is available, you can use port-forwarding to access the service. Apply the manifest to start the Ollama server:
+Apply the manifest to start the Ollama server. On Azure Local, if no external load balancer is available, use port-forwarding to access the service.
 
 ```powershell
 kubectl apply -f ollama-deployment.yaml                  # apply deployment yaml
@@ -192,11 +190,11 @@ kubectl label node $nodeName accelerator-
 
 ## AI inference with vLLM
 
-Before starting this step, make sure you have completed the cleanup and any required prerequisites. You will then serve a local large language model using the vLLM inference engine on an AKS enabled by Azure Arc cluster. With its optimized memory management approach, vLLM enables efficient text generation for large models. In this step, you will deploy a sample Mistral 7B model (quantized to about 4 GB) using vLLM’s OpenAI‑compatible API, then submit a prompt to validate the response.
+Make sure you have completed the Ollama cleanup above. In this step, you will deploy a **Mistral 7B** model (AWQ quantized, ~4 GB) using vLLM's OpenAI‑compatible API, then submit a prompt to validate the response.
 
 ### Deploying the vLLM model server
 
-After connecting to your Arc-enabled cluster (see Prerequisites), confirm the cluster’s GPU node is ready and run the NVIDIA GPU Operator if not already installed (to provide the device plugin).
+Label the GPU node for scheduling affinity, the same as in the Ollama section above.
 
 ```powershell
 # 1. FIND THE GPU NODE NAME
@@ -300,8 +298,6 @@ spec:
     targetPort: 8000   # The port the vLLM container is actually listening on
 ```
 
-This Deployment launches one vllm/vllm-openai:v0.18.0 container that runs vLLM’s OpenAI-compatible API server for the Mistral-7B model (TheBloke/Mistral-7B-v0.1-AWQ from Hugging Face). The container is configured with a 4096 token context, uses 80% of GPU memory (--gpu-memory-utilization 0.80), and employs AWQ 4-bit quantized weights (to fit in a ~16 GB GPU). It requests 1 GPU, and mounts a 2 GiB emptyDir at /dev/shm for fast memory access. A Service vllm-service is used to forward port 80 to the container’s port 8000 (the API) as a LoadBalancer.
-
 Apply the manifest to start the vLLM server:
 
 ```powershell
@@ -309,7 +305,7 @@ kubectl apply -f vllm-deployment.yaml                       # apply deployment y
 kubectl get pods -l app=vllm-mistral -n vllm-inference -w   # wait for vllm-mistral pod to run
 ```
 
-Kubernetes will pull the container image and start the server. Wait for the vllm-mistral pod to reach Running. Once running, if no external IP address is assigned to vllm-service, open a terminal and port-forward it (e.g. `kubectl port-forward svc/vllm-service -n vllm-inference 8080:80`) to access the API at `http://localhost:8080`.
+Wait for the vllm-mistral pod to reach Running. If no external IP is assigned, port-forward with `kubectl port-forward svc/vllm-service -n vllm-inference 8080:80` to access the API at `http://localhost:8080`.
 
 ### Testing the LLM endpoint
 
@@ -339,6 +335,6 @@ $nodeName = (kubectl get nodes -l accelerator=nvidia-gpu -o jsonpath='{.items[0]
 kubectl label node $nodeName accelerator-
 ```
 
-This removes the vllm-mistral Deployment (stopping the pod) and the Service. If no more GPU inference is needed, you may also remove the GPU Operator (`helm uninstall <release-name>`) to reclaim cluster resources.
+If no more GPU inference is needed, you can also remove the GPU Operator (`helm uninstall <release-name>`) to reclaim cluster resources.
 
 ### Next up: [Predictive AI using Triton and ResNet-50](/2026/04/07/ai-inference-on-aks-arc-part-4)

--- a/website/blog/2026-04-07-ai-inference-on-aks-arc-part-4/index.md
+++ b/website/blog/2026-04-07-ai-inference-on-aks-arc-part-4/index.md
@@ -18,14 +18,10 @@ In this post, you'll deploy NVIDIA Triton Inference Server on your Azure Kuberne
 The previous post covered deploying LLM servers for text generation. This post shifts to predictive AI, specifically computer vision. You'll use NVIDIA Triton Inference Server with the ONNX runtime backend to serve ResNet-50, a classic "hello world" for image classification. Triton is an enterprise-grade, multi-framework model server, and deploying it here gives you a reusable pattern for serving any ONNX model on your AKS enabled by Azure Arc managed cluster.
 
 :::note
-Before you begin, ensure the prerequisites described in [AI Inference on AKS Arc: Series Introduction and Scope](/2026/04/07/ai-inference-on-aks-arc-part-2) are fully met.
-You should have an AKS enabled by Azure Arc cluster (on Azure Local or similar) with a **GPU node** available and configured for **nvidia.com/gpu**.
-The cluster nodes must have **internet access** to download the model. If restricted, you must manually provide the model files via a Persistent Volume. **Expect a delay** during the initial deployment while the **pod downloads** and caches the large model files.
+Before you begin, ensure the [Part 2 prerequisites](/2026/04/07/ai-inference-on-aks-arc-part-2) are met, including a GPU node configured for **nvidia.com/gpu**. Cluster nodes need **internet access** to download models. **Expect a delay** during initial deployment while the pod downloads and caches model files.
 :::
 
 ## AI Inference with Triton (ONNX)
-
-With the environment in place, you'll deploy NVIDIA Triton Inference Server using the ONNX Runtime backend to serve a ResNet‑50 model for image classification. You'll then send a sample image to validate the deployment and confirm that the inference pipeline is working as expected.
 
 ### Preparing storage for the model repository
 
@@ -110,11 +106,6 @@ print('Download Complete')
 "
 ```
 
-:::note
-Ensure the cluster nodes have internet connectivity to download the model file. If internet access from the cluster is restricted, you may have to manually provide the model file to the volume via an alternate method.
-:::
-This one-line command creates the required directory (/models/repository/resnet50/1) and downloads the **ResNet-50 ONNX** model file into it, outputting “Download Complete” when finished.
-
 #### Confirm the model file (~98 MB) exists
 
 ```powershell
@@ -172,8 +163,6 @@ spec:
         persistentVolumeClaim:
           claimName: triton-model-repository-pvc
 ```
-
-This **Deployment** runs a Triton Inference Server container (image nvcr.io/nvidia/tritonserver:24.08-py3) pointing to the model repository at /models/repository (our PVC). This exposes Triton's **HTTP API** (port 8000) and **gRPC API** (port 8001) and requests **1 GPU** (nvidia.com/gpu: 1) to run on a GPU node. The volumeMount attaches the triton-model-repository-pvc at **/models** inside the container so Triton can access the model file.
 
 Apply the Triton deployment manifest and verify Triton server is running
 
@@ -295,7 +284,7 @@ Now you'll test it end-to-end. You'll send an image to Triton and confirm you ge
     }
     ```
 
-The script prompts you for an image path, sends it to Triton's endpoint, and prints the prediction — animal type, breed, and confidence score. Here's an example:
+Example output:
 
 ```output
 Example Output:
@@ -309,7 +298,7 @@ SPECIFIC BREED : sorrel
 SCORE          : 12.5520
 ```
 
-The model correctly identified a horse (sorrel breed) — confirming Triton is serving ResNet-50 predictions. The script maps ImageNet labels to broad animal categories for readability; your actual output will include the full class name.
+The script maps ImageNet labels to broad animal categories for readability; your actual output will include the full class name.
 
 ### Cleanup
 
@@ -319,7 +308,7 @@ To free resources, delete the triton-inference namespace and all its contents:
 kubectl delete namespace triton-inference
 ```
 
-This removes the Triton server Deployment, model-downloader Pod, and PVC. If you installed the GPU Operator specifically for this test, you can also uninstall it via Helm to release cluster resources.
+If you installed the GPU Operator specifically for this test, you can also uninstall it via Helm to release cluster resources.
 
 ### Troubleshooting
 


### PR DESCRIPTION
Trimmed the content to remove duplicate information and keep it simple for a quick read. Parts 1 and 2 have been shortened, while the rest of the technical content remains unchanged.