### PR TITLE
Remove unused labelling workflow. Labels can be added manually.

### DIFF
--- a/.github/policies/bugIssueLifecycleManagement.yml
+++ b/.github/policies/bugIssueLifecycleManagement.yml
@@ -138,20 +138,6 @@ configuration:
                 Please check back shortly to see if any additional information or actions are needed from you.
 
 
-                Thank you!                
-      - description: If a new comment containing 'Released/Shipped/Fixed on release' is added to a bug, add the resolution labels. 
-        if:
-          - payloadType: Issue_Comment
-          - isOpen
-          - hasLabel:
-              label: bug
-          - commentContains:
-              pattern: Released/Shipped/Fixed on release
-              isRegex: False
-        then:
-          - addLabel:
-              label: resolution/fix-released
-          - addLabel:
-              label: resolution/shipped
+                Thank you!
 onFailure: 
 onSuccess:


### PR DESCRIPTION
This pull request simplifies the bug issue lifecycle management policy by removing an automated workflow step related to labeling. Specifically, it eliminates the rule that automatically adds resolution labels when a comment indicates a bug has been released, shipped, or fixed.

This workflow is old and no longer used, so is being removed. Project contributors can still manually add these labels to issues to trigger the auto-close workflow if required.

Policy simplification:

* Removed the rule that added `resolution/fix-released` and `resolution/shipped` labels when a new comment containing 'Released/Shipped/Fixed on release' was added to a bug issue. (`.github/policies/bugIssueLifecycleManagement.yml`)