### PR TITLE
Added GA Tag to App Routing Istio Post

### DIFF
--- a/website/blog/2026-03-18-app-routing-gateway-api/index.md
+++ b/website/blog/2026-03-18-app-routing-gateway-api/index.md
@@ -14,7 +14,7 @@ keywords: ["AKS", "Gateway API", "app routing", "Istio", "ingress", "NGINX", "Ku
 
 ![Gateway API logo](https://gateway-api.sigs.k8s.io/images/logo/logo-text-horizontal.png)
 
-:::tip[Update — now generally available]
+:::tip Update — now generally available
 
 As of **AKS release v20260428 (April 28, 2026)**, both **managed Gateway API** (`--enable-gateway-api`) and the **app routing Istio** Gateway API implementation (`--enable-app-routing-istio`) are **generally available** on AKS.
 

--- a/website/blog/2026-03-18-app-routing-gateway-api/index.md
+++ b/website/blog/2026-03-18-app-routing-gateway-api/index.md
@@ -16,7 +16,9 @@ keywords: ["AKS", "Gateway API", "app routing", "Istio", "ingress", "NGINX", "Ku
 
 :::tip[Update — now generally available]
 
-As of **[AKS v20260428]**, both **managed Gateway API** (`--enable-gateway-api`) and the **app routing Istio** Gateway API implementation (`--enable-app-routing-istio`) are **generally available** on AKS. The preview feature flags and `aks-preview` extension are no longer required.
+As of **AKS release v20260428 (April 28, 2026)**, both **managed Gateway API** (`--enable-gateway-api`) and the **app routing Istio** Gateway API implementation (`--enable-app-routing-istio`) are **generally available** on AKS.
+
+You no longer need preview feature flags or the `aks-preview` extension; the steps later in this post reflect the original preview experience.
 
 :::
 

--- a/website/blog/2026-03-18-app-routing-gateway-api/index.md
+++ b/website/blog/2026-03-18-app-routing-gateway-api/index.md
@@ -14,6 +14,12 @@ keywords: ["AKS", "Gateway API", "app routing", "Istio", "ingress", "NGINX", "Ku
 
 ![Gateway API logo](https://gateway-api.sigs.k8s.io/images/logo/logo-text-horizontal.png)
 
+:::tip[Update — now generally available]
+
+As of **[AKS v20260428]**, both **managed Gateway API** (`--enable-gateway-api`) and the **app routing Istio** Gateway API implementation (`--enable-app-routing-istio`) are **generally available** on AKS. The preview feature flags and `aks-preview` extension are no longer required.
+
+:::
+
 We're announcing preview support for the **Kubernetes Gateway API** in the AKS application routing add-on. This brings a modern, role-oriented traffic management model to AKS — and establishes a clear migration path ahead of the [upcoming Ingress-NGINX retirement](#why-now-the-ingress-nginx-retirement).
 
 <!-- truncate -->


### PR DESCRIPTION
Adding a GA tag to clarify that app routing istio and managed gw are now GA