### PR TITLE
Remove "(preview)" from App Routing Gateway API blog title

### DIFF
--- a/website/blog/2026-03-18-app-routing-gateway-api/index.md
+++ b/website/blog/2026-03-18-app-routing-gateway-api/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Announcing Gateway API support for App Routing (preview)"
+title: "Announcing Gateway API support for App Routing"
 date: "2026-03-18"
 description: "The AKS app routing add-on now supports the Kubernetes Gateway API via a meshless Istio control plane — the recommended path to migrate from Ingress-NGINX."
 authors: ["jaiveer-katariya"]


### PR DESCRIPTION
## Summary
- Removes the `(preview)` qualifier from the title of the "Announcing Gateway API support for App Routing" blog post, since the feature is now GA.

Title-only change — no body content was modified.

## Test plan
- [x] Verified diff is a single-line title change in `website/blog/2026-03-18-app-routing-gateway-api/index.md`
- [ ] Blog renders correctly in the docs site build

🤖 Generated with [Claude Code](https://claude.com/claude-code)