### PR TITLE
Add Kueue and Cluster Autoscaler Gang Scheduling on AKS example

### DIFF
--- a/examples/kueue-and-ray-on-aks/2-kueue-queues/README.md
+++ b/examples/kueue-and-ray-on-aks/2-kueue-queues/README.md
@@ -7,13 +7,21 @@ resource management for the Ray workloads. This module sets up:
 - ResourceFlavors that map to CPU and GPU node pools
 - Queue configurations that control how workloads are admitted to the cluster
 
-Two queue configurations are provided as **independent demos** — apply one or
-the other, not both:
+Three queue configurations are provided as **independent demos** — apply one,
+not several:
 
 | Configuration | File | What it demonstrates |
 |---------------|------|----------------------|
 | **Single queue** | `manifests/20-single-queue.yaml` | One ClusterQueue with admission backpressure — one workload runs, the next waits |
 | **Team queues** | `manifests/30-team-queues.yaml` | Two ClusterQueues in a shared cohort with borrowing and preemption |
+| **Autoscale queue** | `manifests/40-autoscale-queue.yaml` | A ProvisioningRequest AdmissionCheck that drives the AKS cluster autoscaler to provision capacity *before* admission |
+
+> The single and team queues admit against a **fixed** quota on the
+> already-provisioned GPU node. The autoscale queue is different: it pairs Kueue
+> with the cluster autoscaler so capacity is provisioned **on demand**. See
+> [Autoscale queue — provision on demand](#autoscale-queue--provision-on-demand)
+> below, and the [cas-batch-job](../3-workloads/cas-batch-job/) workload that
+> uses it.
 
 ## Prerequisites
 
@@ -39,6 +47,7 @@ the other, not both:
 | `manifests/10-resource-flavors.yaml` | `default` (any node) and `gpu` (NVIDIA accelerator nodes) ResourceFlavors |
 | `manifests/20-single-queue.yaml` | `cluster-queue` ClusterQueue + `default` LocalQueue |
 | `manifests/30-team-queues.yaml` | `team-a-cq` / `team-b-cq` ClusterQueues in `shared-cohort` + `team-a` / `team-b` LocalQueues |
+| `manifests/40-autoscale-queue.yaml` | `scalepool` ResourceFlavor + `cas-provisioning` AdmissionCheck + `cas-provreq-config` ProvisioningRequestConfig + `cas-cluster-queue` ClusterQueue + `cas-local-queue` LocalQueue (in its own `cas-kueue-demo` namespace) |
 
 ## Apply
 
@@ -61,6 +70,10 @@ kubectl apply -f manifests/20-single-queue.yaml
 
 #   Option B — Team queues (multi-tenant borrowing + preemption demo)
 kubectl apply -f manifests/30-team-queues.yaml
+
+#   Option C — Autoscale queue (provision capacity on demand via CAS)
+#   Requires an autoscaling `scalepool` pool — see the section below.
+kubectl apply -f manifests/40-autoscale-queue.yaml
 ```
 
 > **⚠️ Choose one.** `20-single-queue.yaml` and `30-team-queues.yaml` are
@@ -236,6 +249,43 @@ Preemption policy:
 **Demo idea:** Submit an 8-GPU RayJob to `team-a`, watch it consume all GPUs.
 Then submit a 4-GPU RayJob to `team-b` — Kueue will preempt Team A down to 4
 GPUs and admit Team B's job. See Module 3 for ready-to-run workload examples.
+
+### Autoscale queue — provision on demand
+
+The single- and team-queue configs admit workloads against a **fixed** quota
+that assumes the GPU node already exists. The autoscale queue instead pairs
+Kueue with the AKS **cluster autoscaler (CAS)** so nodes are provisioned *before*
+a workload is admitted:
+
+```
+Workload (suspend: true, queue-name: cas-local-queue)
+   │
+   ▼
+Kueue ──► AdmissionCheck cas-provisioning ──► ProvisioningRequest ──► CAS
+   │                                                                    │
+   └──────── admitted once nodes exist ◄──── Provisioned=True ◄─────────┘
+```
+
+Three objects wire the gate together (all in `40-autoscale-queue.yaml`):
+
+- **ProvisioningRequestConfig** `cas-provreq-config` selects the
+  `best-effort-atomic-scale-up.autoscaling.x-k8s.io` provisioning class — CAS
+  adds the requested capacity as a single atomic increase (all-or-nothing),
+  which is what batch/gang workloads want.
+- **AdmissionCheck** `cas-provisioning` uses the
+  `kueue.x-k8s.io/provisioning-request` controller and points at that config.
+- **ClusterQueue** `cas-cluster-queue` gates admission on `cas-provisioning` via
+  `admissionChecksStrategy`, so every workload it admits first goes through the
+  provisioning gate. It admits onto the `scalepool` ResourceFlavor
+  (`agentpool: scalepool`).
+
+**Requirements:**
+
+- An autoscaling CPU pool named `scalepool`
+  (`az aks nodepool add ... --enable-cluster-autoscaler --min-count 1 --max-count 5`).
+
+The [cas-batch-job](../3-workloads/cas-batch-job/) workload in Module 3 submits
+a suspended Job through this queue and walks through the scale-up end to end.
 
 ### Quota sizing
 

--- a/examples/kueue-and-ray-on-aks/2-kueue-queues/manifests/40-autoscale-queue.yaml
+++ b/examples/kueue-and-ray-on-aks/2-kueue-queues/manifests/40-autoscale-queue.yaml
@@ -1,0 +1,111 @@
+# Autoscale queue — ProvisioningRequest AdmissionCheck driving the AKS cluster autoscaler.
+#
+# The single-queue and team-queue configs (20-/30-) admit workloads against a
+# FIXED quota that assumes the GPU node already exists. This configuration is
+# different: it pairs Kueue with the AKS cluster autoscaler (CAS) so capacity is
+# provisioned ON DEMAND, before the workload is admitted.
+#
+# How it fits together:
+#
+#   1. ProvisioningRequestConfig + AdmissionCheck delegate capacity provisioning
+#      to CAS. When Kueue needs capacity for a workload, the AdmissionCheck asks
+#      CAS — via a ProvisioningRequest — to atomically scale up the pool BEFORE
+#      the workload is admitted. The workload only starts once the nodes exist.
+#
+#   2. A ClusterQueue references that AdmissionCheck, so every workload routed
+#      through the queue goes through the provisioning gate first.
+#
+# provisioningClassName `best-effort-atomic-scale-up.autoscaling.x-k8s.io` tells
+# CAS to add all the requested capacity as a single atomic increase (all-or-
+# nothing), which is what batch/gang workloads want.
+#
+# This targets an AUTOSCALING CPU pool named `scalepool` (see the README for how
+# to add it with `az aks nodepool add --enable-cluster-autoscaler`). It is an
+# independent configuration — apply it INSTEAD OF 20-/30-, not alongside them.
+#
+# Unlike the Ray configs in this directory, this one is self-contained: it
+# creates its own `cas-kueue-demo` namespace and does not use the `ray`
+# namespace, because the workload it gates is a plain batch Job, not a RayJob.
+#
+# Apply:
+#   kubectl apply -f 40-autoscale-queue.yaml
+#
+# Verify:
+#   kubectl get admissioncheck cas-provisioning
+#   kubectl get clusterqueue cas-cluster-queue
+#   kubectl -n cas-kueue-demo get localqueue cas-local-queue
+---
+# Namespace for the cluster autoscaler + Kueue demo.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cas-kueue-demo
+---
+# ResourceFlavor pinned to the autoscaling CPU pool. AKS stamps every node in a
+# pool with `agentpool: <pool-name>`, so this flavor only admits onto scalepool.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: scalepool
+spec:
+  nodeLabels:
+    agentpool: scalepool
+---
+# AdmissionCheck that delegates capacity provisioning to CAS via ProvisioningRequest.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: AdmissionCheck
+metadata:
+  name: cas-provisioning
+spec:
+  controllerName: kueue.x-k8s.io/provisioning-request
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: ProvisioningRequestConfig
+    name: cas-provreq-config
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ProvisioningRequestConfig
+metadata:
+  name: cas-provreq-config
+spec:
+  provisioningClassName: best-effort-atomic-scale-up.autoscaling.x-k8s.io
+  managedResources:
+    - cpu
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: cas-cluster-queue
+spec:
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+    - coveredResources:
+        - cpu
+        - memory
+      flavors:
+        - name: scalepool
+          resources:
+            - name: cpu
+              # Upper bound Kueue will admit before asking CAS to grow the pool.
+              # Set generously here so quota is never the limiting factor — the
+              # pool's --max-count is what actually caps the scale-up. Lower it
+              # to max-count × per-node cores (e.g. 5 × 4 = 20) if you want
+              # Kueue to enforce the ceiling too.
+              nominalQuota: "100"
+            - name: memory
+              nominalQuota: 200Gi
+  # Gate admission on the provisioning check, scoped to the scalepool flavor.
+  # This is the form the upstream Kueue provisioning guide uses.
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: cas-provisioning
+        onFlavors: [scalepool]
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: cas-local-queue
+  namespace: cas-kueue-demo
+spec:
+  clusterQueue: cas-cluster-queue

--- a/examples/kueue-and-ray-on-aks/3-workloads/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/README.md
@@ -31,6 +31,11 @@ The shared base templates in [`_template/`](_template/) define the standard
 fields used by every workload. Per-example templates extend these with
 workload-specific pip packages, env vars, and resource counts.
 
+> **Exception:** [`cas-batch-job/`](cas-batch-job/) is a plain Kubernetes Job
+> (no Ray, no `envsubst`) applied directly with `kubectl apply -f`. It
+> demonstrates the cluster-autoscaler ProvisioningRequest path rather than a Ray
+> runtime, so it doesn't use the template system described here.
+
 ### Standard fields (all workloads)
 
 | Field | Value | Reason |
@@ -93,17 +98,29 @@ Ray Serve. Loads the LoRA adapter from blob storage on startup.
 - Access: `kubectl -n ray port-forward svc/${SERVICE_NAME}-serve-svc 8000:8000`
 - See [online-serving/](online-serving/)
 
+### 5. cas-batch-job/ — provision capacity on demand (cluster autoscaler)
+A plain Kubernetes batch Job (no Ray) that demonstrates the **ProvisioningRequest
+→ cluster autoscaler** path. Where the examples above admit against a fixed quota
+on an existing GPU node, this one drives the AKS cluster autoscaler to grow an
+autoscaling CPU pool *before* the Job is admitted — capacity provisioned
+just-in-time.
+
+- **CPU only** — 3 pods × 1800m on an autoscaling `scalepool`
+- Queue: `cas-local-queue` in the `cas-kueue-demo` namespace (the ProvisioningRequest-gated queue from Module 2)
+- Requires: an autoscaling `scalepool` pool
+- See [cas-batch-job/](cas-batch-job/)
+
 ## Comparison
 
-| | aurora-finetune | llm-training | batch-inference | online-serving |
-|--|--|--|--|--|
-| Kind | RayJob | RayJob | RayJob | RayService |
-| Kueue-admitted | ✓ | ✓ | ✓ | ✗ |
-| GPUs | 1 | 4 | 1 | 1 |
-| Queue label | `default` | `default` | `default` | — |
-| Deps | Aurora, torch, azure-storage-blob | LLaMA-Factory, azure-storage-blob | vLLM, azure-storage-blob | Aurora, azure-storage-blob |
-| Reads from blob | `aurora/data/` (init/truth) | `llm-pipeline/data/` (train.jsonl) | `llm-pipeline/data/` + `lora/` | `aurora/checkpoints/` (adapter) |
-| Writes to blob | `aurora/checkpoints/` | `llm-pipeline/lora/` | `llm-pipeline/inference/` | — |
+| | aurora-finetune | llm-training | batch-inference | online-serving | cas-batch-job |
+|--|--|--|--|--|--|
+| Kind | RayJob | RayJob | RayJob | RayService | Job |
+| Kueue-admitted | ✓ | ✓ | ✓ | ✗ | ✓ |
+| GPUs | 1 | 4 | 1 | 1 | 0 (CPU) |
+| Queue label | `default` | `default` | `default` | — | `cas-local-queue` |
+| Deps | Aurora, torch, azure-storage-blob | LLaMA-Factory, azure-storage-blob | vLLM, azure-storage-blob | Aurora, azure-storage-blob | none (busybox) |
+| Reads from blob | `aurora/data/` (init/truth) | `llm-pipeline/data/` (train.jsonl) | `llm-pipeline/data/` + `lora/` | `aurora/checkpoints/` (adapter) | — |
+| Writes to blob | `aurora/checkpoints/` | `llm-pipeline/lora/` | `llm-pipeline/inference/` | — | — |
 
 ## Quick start
 

--- a/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/README.md
@@ -31,6 +31,27 @@ The atomic `best-effort-atomic-scale-up.autoscaling.x-k8s.io` provisioning class
 adds the whole capacity block at once, avoiding the half-scheduled gang problem
 where some pods land and others sit Pending.
 
+### State transitions
+
+A successful run passes through these states in order. If a run stalls, the last
+state reached tells you which component to look at — see
+[Troubleshooting](#troubleshooting).
+
+| # | State | Check |
+|---|-------|-------|
+| 1 | Job exists, `suspend: true` | `kubectl -n cas-kueue-demo get job kueue-cas-job -o jsonpath='{.spec.suspend}'` → `true` |
+| 2 | Kueue creates a Workload | `kubectl -n cas-kueue-demo get workloads` |
+| 3 | AdmissionCheck is `Pending` | `kubectl -n cas-kueue-demo get workloads -o jsonpath='{.items[*].status.admissionChecks[*].state}'` |
+| 4 | ProvisioningRequest created | `kubectl -n cas-kueue-demo get provisioningrequest` |
+| 5 | ProvisioningRequest `Provisioned=True` | `kubectl -n cas-kueue-demo get provisioningrequest -o jsonpath='{.items[*].status.conditions[?(@.type=="Provisioned")].status}'` |
+| 6 | Workload admitted | `kubectl -n cas-kueue-demo get workloads -o jsonpath='{.items[*].status.conditions[?(@.type=="Admitted")].status}'` |
+| 7 | Job suspension flips to `false` | `kubectl -n cas-kueue-demo get job kueue-cas-job -o jsonpath='{.spec.suspend}'` → `false` |
+| 8 | Pods scheduled on new nodes | `kubectl -n cas-kueue-demo get pods -o wide` |
+| 9 | Job completes | `kubectl -n cas-kueue-demo get job kueue-cas-job` → `Complete 3/3` |
+
+Steps 4–5 are the CAS scale-up and take the longest — allow a few minutes for
+new nodes to join.
+
 ## Prerequisites
 
 - Module 1 cluster deployed and Kueue running.
@@ -93,6 +114,45 @@ kueue-cas-job   Complete   3/3           45s        6m
 
 ## Clean up
 
+Remove things in this order — the Job first, so Kueue releases its Workload and
+the ProvisioningRequest is garbage-collected before the queues that own them go
+away.
+
 ```bash
+# 1. The Job. Deleting it releases the Workload; Kueue then removes the
+#    ProvisioningRequest it created.
 kubectl delete -f manifests/job.yaml
+
+# 2. Confirm nothing is left holding quota.
+kubectl -n cas-kueue-demo get workloads,provisioningrequest
 ```
+
+If you are done with the demo entirely, also remove the queue objects and the
+node pool:
+
+```bash
+# 3. The Kueue objects from Module 2. This deletes the cas-kueue-demo namespace
+#    (and cas-local-queue inside it), plus the cluster-scoped cas-cluster-queue,
+#    cas-provisioning AdmissionCheck, cas-provreq-config, and scalepool
+#    ResourceFlavor.
+kubectl delete -f ../../2-kueue-queues/manifests/40-autoscale-queue.yaml
+
+# 4. The autoscaling node pool added in the Prerequisites. Skip this if
+#    scalepool was already part of your Module 1 cluster.
+az aks nodepool delete \
+  --resource-group <rg> --cluster-name <cluster> \
+  --name scalepool
+```
+
+Verify the cluster is clean:
+
+```bash
+kubectl get clusterqueue cas-cluster-queue          # NotFound
+kubectl get admissioncheck cas-provisioning         # NotFound
+kubectl get resourceflavor scalepool                # NotFound
+kubectl get namespace cas-kueue-demo                # NotFound
+```
+
+> If the `cas-kueue-demo` namespace hangs in `Terminating`, a Workload is still
+> pending finalization. Re-run step 1 and confirm step 2 returns no resources
+> before retrying the namespace delete.

--- a/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/README.md
@@ -1,0 +1,98 @@
+# cas-batch-job — provision capacity on demand with Kueue + cluster autoscaler
+
+A plain Kubernetes batch Job that demonstrates the **ProvisioningRequest → AKS
+cluster autoscaler (CAS)** path. The other Module 3 workloads admit against a
+fixed quota on an already-provisioned GPU node; this one instead asks CAS to
+*grow* an autoscaling CPU pool before the Job is admitted, so batch capacity is
+provisioned just-in-time.
+
+This isolates the Kueue↔CAS integration from the Ray runtime — it's the
+simplest way to see a *provision-first* scale-up end to end.
+
+## How it works
+
+```
+Job (suspend: true, queue-name: cas-local-queue)
+   │
+   ▼
+Kueue creates a Workload ──► AdmissionCheck cas-provisioning
+   │                              │
+   │                              ▼
+   │                        ProvisioningRequest  ──►  cluster autoscaler
+   │                              │                     atomically scales
+   │                              ▼                     up `scalepool`
+   └──── admitted once nodes exist ◄── Provisioned=True
+   │
+   ▼
+suspend flips to false → 3 pods schedule on the new nodes → Job completes
+```
+
+The atomic `best-effort-atomic-scale-up.autoscaling.x-k8s.io` provisioning class
+adds the whole capacity block at once, avoiding the half-scheduled gang problem
+where some pods land and others sit Pending.
+
+## Prerequisites
+
+- Module 1 cluster deployed and Kueue running.
+- An **autoscaling** CPU pool named `scalepool`. If your Module 1 cluster
+  doesn't have one, add it:
+  ```bash
+  az aks nodepool add \
+    --resource-group <rg> --cluster-name <cluster> \
+    --name scalepool --mode User \
+    --node-vm-size Standard_D4s_v3 \
+    --enable-cluster-autoscaler --min-count 1 --max-count 5
+  ```
+- The autoscale queue applied from Module 2:
+  ```bash
+  kubectl apply -f ../../2-kueue-queues/manifests/40-autoscale-queue.yaml
+  ```
+
+## Submit
+
+```bash
+kubectl apply -f manifests/job.yaml
+```
+
+The Job requests 3 pods at 1800m CPU each. On a pool starting at one 4-core node
+they cannot all fit, so Kueue asks CAS to scale up before admitting them.
+
+## Watch the flow
+
+```bash
+# The Job starts Suspended
+kubectl -n cas-kueue-demo get job kueue-cas-job
+
+# Kueue creates a Workload, then a ProvisioningRequest
+kubectl -n cas-kueue-demo get workloads
+kubectl -n cas-kueue-demo get provisioningrequest
+
+# CAS provisions the nodes (Provisioned=True), the pool grows
+kubectl -n cas-kueue-demo get provisioningrequest -o yaml | grep -A5 conditions
+kubectl get nodes -l agentpool=scalepool
+
+# Job runs to completion
+kubectl -n cas-kueue-demo get job kueue-cas-job -w   # COMPLETIONS 3/3
+```
+
+Expected end state:
+
+```output
+NAME            STATUS     COMPLETIONS   DURATION   AGE
+kueue-cas-job   Complete   3/3           45s        6m
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Job stays `Suspended`, no ProvisioningRequest | Wrong queue-name label | Verify `kueue.x-k8s.io/queue-name: cas-local-queue` matches the LocalQueue |
+| ProvisioningRequest created but `status.conditions` empty | Cluster autoscaler not yet processing the request | Check the autoscaler is enabled on `scalepool` and re-check after a minute |
+| `Provisioned=False` with reason `CapacityIsNotFound` | Pool can't reach the requested size — existing workloads occupy it, or the request exceeds `--max-count` | Free capacity or raise `--max-count`. CAS keeps retrying; the Job stays suspended rather than partially scheduling |
+| Pods Pending after admission | Node label mismatch | Confirm `scalepool` nodes carry `agentpool=scalepool` (`kubectl get nodes --show-labels`) |
+
+## Clean up
+
+```bash
+kubectl delete -f manifests/job.yaml
+```

--- a/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/README.md
@@ -31,6 +31,36 @@ The atomic `best-effort-atomic-scale-up.autoscaling.x-k8s.io` provisioning class
 adds the whole capacity block at once, avoiding the half-scheduled gang problem
 where some pods land and others sit Pending.
 
+### Why this matters: no wasted spend on partial capacity
+
+Because pods stay gated until the *entire* capacity block is provisioned, the
+cluster autoscaler can quickly clean up partially provisioned nodes — no pods
+have been scheduled on them, so nothing blocks scale-down. This is especially
+valuable when a scale-up is cut short by capacity or quota limits: instead of
+paying for a handful of nodes that sit half-used while the gang waits, the
+autoscaler reclaims them and the Job simply stays suspended until the full
+block can be satisfied. For gang-scheduled batch and AI training jobs, this
+significantly reduces wasteful compute spend.
+
+If you are cost sensitive and want those partially provisioned nodes released
+as fast as possible, run an aggressive scale-down
+[cluster autoscaler profile](https://learn.microsoft.com/azure/aks/cluster-autoscaler?tabs=azure-cli#cluster-autoscaler-profile-settings)
+on the cluster, for example:
+
+```bash
+az aks update \
+  --resource-group <rg> --name <cluster> \
+  --cluster-autoscaler-profile \
+      scale-down-unneeded-time=1m \
+      scale-down-delay-after-add=1m \
+      scale-down-unready-time=5m \
+      max-graceful-termination-sec=60
+```
+
+These profile settings are cluster-wide and apply to the scale-up and
+scale-down that this ProvisioningRequest integration triggers, so tune them
+alongside the queue configuration rather than in isolation.
+
 ### State transitions
 
 A successful run passes through these states in order. If a run stalls, the last
@@ -54,6 +84,9 @@ new nodes to join.
 
 ## Prerequisites
 
+- An AKS cluster running Kubernetes 1.30+ with the cluster autoscaler enabled
+  (ProvisioningRequest support), and Kueue v0.7.0 or later. The companion
+  AKS how-to guide lists the supported version matrix in detail.
 - Module 1 cluster deployed and Kueue running.
 - An **autoscaling** CPU pool named `scalepool`. If your Module 1 cluster
   doesn't have one, add it:
@@ -64,6 +97,10 @@ new nodes to join.
     --node-vm-size Standard_D4s_v3 \
     --enable-cluster-autoscaler --min-count 1 --max-count 5
   ```
+  `--min-count 0` also works — the pool can scale from zero, and the
+  ProvisioningRequest simply provisions the whole block from empty. `--max-count`
+  is the real ceiling: a request larger than it fails with
+  `Provisioned=False` / `CapacityIsNotFound` rather than partially scheduling.
 - The autoscale queue applied from Module 2:
   ```bash
   kubectl apply -f ../../2-kueue-queues/manifests/40-autoscale-queue.yaml
@@ -101,6 +138,30 @@ Expected end state:
 ```output
 NAME            STATUS     COMPLETIONS   DURATION   AGE
 kueue-cas-job   Complete   3/3           45s        6m
+```
+
+## Observability
+
+If a run stalls, these are the logs and events that explain why, in the order
+the request flows through the system:
+
+```bash
+# Workload conditions (QuotaReserved, Admitted) and admission-check state
+kubectl -n cas-kueue-demo get workloads -o yaml
+
+# AdmissionCheck status
+kubectl get admissioncheck cas-provisioning -o yaml
+
+# ProvisioningRequest conditions and events (Provisioned / CapacityIsNotFound)
+kubectl -n cas-kueue-demo describe provisioningrequest
+
+# Kueue controller logs — provisioning-request creation and failures
+kubectl -n kueue-system logs deploy/kueue-controller-manager -c manager --tail=200
+
+# Cluster autoscaler decisions (AKS surfaces these as cluster events)
+kubectl get events -A --field-selector source=cluster-autoscaler \
+  --sort-by=.lastTimestamp
+kubectl -n kube-system describe configmap cluster-autoscaler-status
 ```
 
 ## Troubleshooting

--- a/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/README.md
@@ -84,7 +84,7 @@ new nodes to join.
 
 ## Prerequisites
 
-- An AKS cluster running Kubernetes 1.30+ with the cluster autoscaler enabled
+- An AKS cluster running Kubernetes 1.33+ with the cluster autoscaler enabled
   (ProvisioningRequest support), and Kueue v0.7.0 or later. The companion
   AKS how-to guide lists the supported version matrix in detail.
 - Module 1 cluster deployed and Kueue running.

--- a/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/manifests/job.yaml
+++ b/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/manifests/job.yaml
@@ -1,0 +1,50 @@
+# A suspended batch Job routed through Kueue's autoscale queue.
+#
+# Unlike the Ray examples in this module, this is a plain Kubernetes Job — it
+# exists to demonstrate the ProvisioningRequest -> cluster autoscaler (CAS) path
+# without the Ray runtime. The Job requests more CPU than the autoscaling pool's
+# current nodes can satisfy, so Kueue's ProvisioningRequest AdmissionCheck asks
+# CAS to add nodes BEFORE admitting it. The flow:
+#
+#   suspend: true          -> Job created but no pods yet
+#   queue-name label       -> Kueue picks it up, creates a Workload
+#   AdmissionCheck         -> Kueue creates a ProvisioningRequest for CAS
+#   CAS atomic scale-up    -> scalepool grows to fit the 3 pods
+#   suspend flipped false  -> pods schedule onto the new nodes, Job runs
+#
+# 3 pods x 1800m CPU on 4-core nodes forces a scale-up beyond the single
+# starting node (~2 schedulable pods/node).
+#
+# Each pod sleeps 30s and exits, so the Job reaches Complete 3/3 and the pool
+# scales back down afterwards.
+#
+# Submit:
+#   kubectl apply -f manifests/job.yaml
+#
+# Watch the ProvisioningRequest and scale-up:
+#   kubectl -n cas-kueue-demo get provisioningrequest
+#   kubectl get nodes -l agentpool=scalepool -w
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kueue-cas-job
+  namespace: cas-kueue-demo
+  labels:
+    kueue.x-k8s.io/queue-name: cas-local-queue
+spec:
+  parallelism: 3
+  completions: 3
+  suspend: true
+  template:
+    spec:
+      nodeSelector:
+        agentpool: scalepool
+      containers:
+        - name: worker
+          image: mcr.microsoft.com/azurelinux/busybox:1.36
+          command: ["sh", "-c", "echo running on $(hostname); sleep 30"]
+          resources:
+            requests:
+              cpu: "1800m"
+              memory: "256Mi"
+      restartPolicy: Never

--- a/examples/kueue-and-ray-on-aks/README.md
+++ b/examples/kueue-and-ray-on-aks/README.md
@@ -73,8 +73,8 @@ keys in the manifests.
 | Module | Directory | What you'll do |
 |--------|-----------|----------------|
 | 1 — Infrastructure | [`1-infrastructure/`](1-infrastructure/) | Provision the AKS cluster, KubeRay + Kueue operators, Blob storage, workload identity, and pre-staged datasets with one `terraform apply` |
-| 2 — Kueue Queues | [`2-kueue-queues/`](2-kueue-queues/) | Apply ResourceFlavors and ClusterQueues — a single backpressure queue or two teams sharing a cohort with borrowing |
-| 3 — Workloads | [`3-workloads/`](3-workloads/) | Submit Ray examples: Aurora fine-tune, LLM training, batch inference (RayJob), and online serving (RayService) |
+| 2 — Kueue Queues | [`2-kueue-queues/`](2-kueue-queues/) | Apply ResourceFlavors and ClusterQueues — a single backpressure queue, two teams sharing a cohort with borrowing, or an autoscale queue that drives the cluster autoscaler on demand |
+| 3 — Workloads | [`3-workloads/`](3-workloads/) | Submit Ray examples: Aurora fine-tune, LLM training, batch inference (RayJob), online serving (RayService), and a cluster-autoscaler batch Job |
 
 Work through them in order — each module assumes the previous one is in place.
 
@@ -84,6 +84,7 @@ The workloads in Module 3:
 - **[LLM training](3-workloads/llm-training/)** — Distributed Qwen2.5-7B LoRA fine-tune with Ray Train and LLaMA-Factory (RayJob)
 - **[Batch inference](3-workloads/batch-inference/)** — Parallel inference over a dataset using Ray Data and ActorPool (RayJob)
 - **[Online serving](3-workloads/online-serving/)** — Aurora model served behind a stable HTTP endpoint with Ray Serve (RayService)
+- **[CAS batch job](3-workloads/cas-batch-job/)** — a plain batch Job that provisions capacity on demand via a Kueue ProvisioningRequest driving the AKS cluster autoscaler
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Add an end-to-end example for running batch jobs on AKS with Kueue admission control and the cluster autoscaler
- Kueue gates jobs and, via a ProvisioningRequest AdmissionCheck, asks the cluster autoscaler to atomically provision capacity *before* the job is admitted (provision-first, avoids half-scheduled gangs)
- Three modules walk through infrastructure, queue + provisioning-gate configuration, and workload submission

## What's included

| Module | Content |
|--------|---------|
| 1 — Infrastructure | AKS cluster with an autoscaling node pool + Kueue install (Helm) |
| 2 — Kueue Queues | ResourceFlavor, ProvisioningRequestConfig, AdmissionCheck, ClusterQueue, LocalQueue |
| 3 — Workload | Suspended Job that triggers an atomic scale-up via ProvisioningRequest |

Follows the structure of the [kueue-and-ray-on-aks](https://github.com/Azure/AKS/tree/master/examples/kueue-and-ray-on-aks) example. A companion how-to in the AKS docs references this directory.

## Test plan

- [x] Manifests apply cleanly on a fresh cluster
- [x] Kueue creates a Workload + ProvisioningRequest for the suspended Job
- [x] Job admitted and runs once nodes are provisioned