### PR TITLE
fix(blog): update AKS agent skill links

### DIFF
--- a/website/blog/2026-04-08-agent-skills-for-aks/index.md
+++ b/website/blog/2026-04-08-agent-skills-for-aks/index.md
@@ -26,8 +26,8 @@ While AI agents already carry a good baseline of Kubernetes and AKS knowledge, t
 
 The first release includes the following skills:
 
-1. A high-level [**AKS best practices** skill](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugin/skills/azure-kubernetes/SKILL.md)
-1. Sub-skills for [**AKS troubleshooting**](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugin/skills/azure-diagnostics/troubleshooting/aks/aks-troubleshooting.md)
+1. A high-level [**AKS best practices** skill](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugins/azure-skills/skills/azure-kubernetes/SKILL.md)
+1. Sub-skills for [**AKS troubleshooting**](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugins/azure-skills/skills/azure-diagnostics/troubleshooting/aks/aks-troubleshooting.md)
 
 The **AKS best practices** skill guides agents through cluster configuration recommendations across networking, upgrade strategy, security, reliability, scale, and more. The guidance reflects what the AKS engineering team recommends for production clusters for optimal performance and uptime, along with specific defaults and critical decisions that apply to AKS. After installing the skill, try the following commands to invoke the skill and receive targeted recommendations for your AKS cluster:
 
@@ -113,6 +113,6 @@ AKS skills give your agents a baseline of production AKS knowledge using the sam
 
 ## Resources
 
-- Link to the [azure-kubernetes skill](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugin/skills/azure-kubernetes/SKILL.md)
-- Link to the [azure-diagnostics skill](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugin/skills/azure-diagnostics/SKILL.md)
+- Link to the [azure-kubernetes skill](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugins/azure-skills/skills/azure-kubernetes/SKILL.md)
+- Link to the [azure-diagnostics skill](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/plugins/azure-skills/skills/azure-diagnostics/SKILL.md)
 - Find all skills in the [Microsoft/skills repo](https://github.com/microsoft/skills/tree/main/.github/plugins/azure-skills)


### PR DESCRIPTION
## Summary

- Update stale GitHub Copilot for Azure skill links after the repository moved skills from `plugin/skills` to `plugins/azure-skills/skills`
- Fix links in both the Available skills and Resources sections

## Validation

- Confirmed all three unique replacement URLs return HTTP 200
- Confirmed no `/blob/main/plugin/skills/` paths remain in the article