### PR TITLE
August 2026 assignee and label updates

### DIFF
--- a/.github/policies/manageAssignees.yml
+++ b/.github/policies/manageAssignees.yml
@@ -147,7 +147,6 @@ configuration:
           - mentionUsers:
               mentionees:
               - Azure/aks-portal
-              - smsft
               - chandraneel
               replyTemplate: ${mentionees} would you be able to assist?
               assignMentionees: True
@@ -483,7 +482,6 @@ configuration:
           - mentionUsers:
               mentionees:
               - dipti-pai
-              - bavneetsingh16
               - ponatara
               replyTemplate: ${mentionees} would you be able to assist?
               assignMentionees: True

--- a/.github/policies/manageAssignees.yml
+++ b/.github/policies/manageAssignees.yml
@@ -387,7 +387,6 @@ configuration:
           - mentionUsers:
               mentionees:
               - robbiezhang
-              - kthakar1990
               replyTemplate: ${mentionees} would you be able to assist?
               assignMentionees: True
         # Documentation


### PR DESCRIPTION
This pull request makes minor updates to the `.github/policies/manageAssignees.yml` file, specifically removing several users from the `mentionees` lists in different sections. These changes adjust which users are notified and assigned when certain policies are triggered. No other significant changes are present.

Most important changes:

* Removed `smsft` from the `mentionees` list for the Azure/aks-portal section.
* Removed `kthakar1990` from the `mentionees` list for the robbiezhang section.
* Removed `bavneetsingh16` from the `mentionees` list for the dipti-pai section.