### PR TITLE
Add end-to-end GPU labs (Kueue + cluster autoscaler) to the Ray on AKS example

### DIFF
--- a/examples/kueue-and-ray-on-aks/2-kueue-queues/README.md
+++ b/examples/kueue-and-ray-on-aks/2-kueue-queues/README.md
@@ -7,13 +7,21 @@ resource management for the Ray workloads. This module sets up:
 - ResourceFlavors that map to CPU and GPU node pools
 - Queue configurations that control how workloads are admitted to the cluster
 
-Two queue configurations are provided as **independent demos** — apply one or
-the other, not both:
+Three queue configurations are provided as **independent demos** — apply one,
+not several:
 
 | Configuration | File | What it demonstrates |
 |---------------|------|----------------------|
 | **Single queue** | `manifests/20-single-queue.yaml` | One ClusterQueue with admission backpressure — one workload runs, the next waits |
 | **Team queues** | `manifests/30-team-queues.yaml` | Two ClusterQueues in a shared cohort with borrowing and preemption |
+| **Autoscale queue** | `manifests/40-autoscale-queue.yaml` | A ProvisioningRequest AdmissionCheck that drives the AKS cluster autoscaler to provision capacity *before* admission |
+
+> The single and team queues admit against a **fixed** quota on the
+> already-provisioned GPU node. The autoscale queue is different: it pairs Kueue
+> with the cluster autoscaler so capacity is provisioned **on demand**. See
+> [Autoscale queue — provision on demand](#autoscale-queue--provision-on-demand)
+> below, and the [cas-batch-job](../3-workloads/cas-batch-job/) workload that
+> uses it.
 
 ## Prerequisites
 
@@ -39,6 +47,7 @@ the other, not both:
 | `manifests/10-resource-flavors.yaml` | `default` (any node) and `gpu` (NVIDIA accelerator nodes) ResourceFlavors |
 | `manifests/20-single-queue.yaml` | `cluster-queue` ClusterQueue + `default` LocalQueue |
 | `manifests/30-team-queues.yaml` | `team-a-cq` / `team-b-cq` ClusterQueues in `shared-cohort` + `team-a` / `team-b` LocalQueues |
+| `manifests/40-autoscale-queue.yaml` | `scalepool` ResourceFlavor + `cas-provisioning` AdmissionCheck + `cas-provreq-config` ProvisioningRequestConfig + `cas-cluster-queue` ClusterQueue + `cas-local-queue` LocalQueue (in its own `cas-kueue-demo` namespace) |
 
 ## Apply
 
@@ -61,6 +70,10 @@ kubectl apply -f manifests/20-single-queue.yaml
 
 #   Option B — Team queues (multi-tenant borrowing + preemption demo)
 kubectl apply -f manifests/30-team-queues.yaml
+
+#   Option C — Autoscale queue (provision capacity on demand via CAS)
+#   Requires an autoscaling `scalepool` pool — see the section below.
+kubectl apply -f manifests/40-autoscale-queue.yaml
 ```
 
 > **⚠️ Choose one.** `20-single-queue.yaml` and `30-team-queues.yaml` are
@@ -236,6 +249,43 @@ Preemption policy:
 **Demo idea:** Submit an 8-GPU RayJob to `team-a`, watch it consume all GPUs.
 Then submit a 4-GPU RayJob to `team-b` — Kueue will preempt Team A down to 4
 GPUs and admit Team B's job. See Module 3 for ready-to-run workload examples.
+
+### Autoscale queue — provision on demand
+
+The single- and team-queue configs admit workloads against a **fixed** quota
+that assumes the GPU node already exists. The autoscale queue instead pairs
+Kueue with the AKS **cluster autoscaler (CAS)** so nodes are provisioned *before*
+a workload is admitted:
+
+```
+Workload (suspend: true, queue-name: cas-local-queue)
+   │
+   ▼
+Kueue ──► AdmissionCheck cas-provisioning ──► ProvisioningRequest ──► CAS
+   │                                                                    │
+   └──────── admitted once nodes exist ◄──── Provisioned=True ◄─────────┘
+```
+
+Three objects wire the gate together (all in `40-autoscale-queue.yaml`):
+
+- **ProvisioningRequestConfig** `cas-provreq-config` selects the
+  `best-effort-atomic-scale-up.autoscaling.x-k8s.io` provisioning class — CAS
+  adds the requested capacity as a single atomic increase (all-or-nothing),
+  which is what batch/gang workloads want.
+- **AdmissionCheck** `cas-provisioning` uses the
+  `kueue.x-k8s.io/provisioning-request` controller and points at that config.
+- **ClusterQueue** `cas-cluster-queue` gates admission on `cas-provisioning` via
+  `admissionChecksStrategy`, so every workload it admits first goes through the
+  provisioning gate. It admits onto the `scalepool` ResourceFlavor
+  (`agentpool: scalepool`).
+
+**Requirements:**
+
+- An autoscaling CPU pool named `scalepool`
+  (`az aks nodepool add ... --enable-cluster-autoscaler --min-count 1 --max-count 5`).
+
+The [cas-batch-job](../3-workloads/cas-batch-job/) workload in Module 3 submits
+a suspended Job through this queue and walks through the scale-up end to end.
 
 ### Quota sizing
 

--- a/examples/kueue-and-ray-on-aks/2-kueue-queues/README.md
+++ b/examples/kueue-and-ray-on-aks/2-kueue-queues/README.md
@@ -15,6 +15,7 @@ not several:
 | **Single queue** | `manifests/20-single-queue.yaml` | One ClusterQueue with admission backpressure — one workload runs, the next waits |
 | **Team queues** | `manifests/30-team-queues.yaml` | Two ClusterQueues in a shared cohort with borrowing and preemption |
 | **Autoscale queue** | `manifests/40-autoscale-queue.yaml` | A ProvisioningRequest AdmissionCheck that drives the AKS cluster autoscaler to provision capacity *before* admission |
+| **GPU autoscale queue** | `manifests/50-gpu-autoscale-queue.yaml` | The same provisioning gate applied to GPUs — atomic scale-up of a GPU pool, with GPU-aware quota |
 
 > The single and team queues admit against a **fixed** quota on the
 > already-provisioned GPU node. The autoscale queue is different: it pairs Kueue
@@ -48,6 +49,7 @@ not several:
 | `manifests/20-single-queue.yaml` | `cluster-queue` ClusterQueue + `default` LocalQueue |
 | `manifests/30-team-queues.yaml` | `team-a-cq` / `team-b-cq` ClusterQueues in `shared-cohort` + `team-a` / `team-b` LocalQueues |
 | `manifests/40-autoscale-queue.yaml` | `scalepool` ResourceFlavor + `cas-provisioning` AdmissionCheck + `cas-provreq-config` ProvisioningRequestConfig + `cas-cluster-queue` ClusterQueue + `cas-local-queue` LocalQueue (in its own `cas-kueue-demo` namespace) |
+| `manifests/50-gpu-autoscale-queue.yaml` | `gpu-a100` ResourceFlavor + `gpu-provisioning` AdmissionCheck + `gpu-provreq-config` ProvisioningRequestConfig + `gpu-cluster-queue` ClusterQueue + `gpu-local-queue` LocalQueue (in its own `gpu-lab` namespace) |
 
 ## Apply
 
@@ -74,6 +76,10 @@ kubectl apply -f manifests/30-team-queues.yaml
 #   Option C — Autoscale queue (provision capacity on demand via CAS)
 #   Requires an autoscaling `scalepool` pool — see the section below.
 kubectl apply -f manifests/40-autoscale-queue.yaml
+
+#   Option D — GPU autoscale queue (provision GPU capacity on demand via CAS)
+#   Requires an autoscaling GPU pool — see ../3-workloads/gpu-lab/.
+kubectl apply -f manifests/50-gpu-autoscale-queue.yaml
 ```
 
 > **⚠️ Choose one.** `20-single-queue.yaml` and `30-team-queues.yaml` are
@@ -286,6 +292,24 @@ Three objects wire the gate together (all in `40-autoscale-queue.yaml`):
 
 The [cas-batch-job](../3-workloads/cas-batch-job/) workload in Module 3 submits
 a suspended Job through this queue and walks through the scale-up end to end.
+
+### GPU variant
+
+`manifests/50-gpu-autoscale-queue.yaml` applies the same gate to GPU capacity.
+Two things change: `managedResources` is `nvidia.com/gpu` rather than `cpu`, so
+only GPU-requesting podsets drive provisioning, and the ResourceFlavor carries
+a toleration for the `nvidia.com/gpu=present:NoSchedule` taint that AKS puts on
+GPU pools.
+
+The stakes are also higher. Atomic scale-up matters more when a half-placed
+gang holds A100s instead of vCPUs — see the
+[GPU labs](../3-workloads/gpu-lab/) for the full walkthrough, including
+multi-node training and queue contention.
+
+**Requirements:**
+
+- An autoscaling GPU pool named `gpupool`
+  (`az aks nodepool add ... --enable-cluster-autoscaler --min-count 0 --max-count 2`).
 
 ### Quota sizing
 

--- a/examples/kueue-and-ray-on-aks/2-kueue-queues/manifests/40-autoscale-queue.yaml
+++ b/examples/kueue-and-ray-on-aks/2-kueue-queues/manifests/40-autoscale-queue.yaml
@@ -1,0 +1,111 @@
+# Autoscale queue — ProvisioningRequest AdmissionCheck driving the AKS cluster autoscaler.
+#
+# The single-queue and team-queue configs (20-/30-) admit workloads against a
+# FIXED quota that assumes the GPU node already exists. This configuration is
+# different: it pairs Kueue with the AKS cluster autoscaler (CAS) so capacity is
+# provisioned ON DEMAND, before the workload is admitted.
+#
+# How it fits together:
+#
+#   1. ProvisioningRequestConfig + AdmissionCheck delegate capacity provisioning
+#      to CAS. When Kueue needs capacity for a workload, the AdmissionCheck asks
+#      CAS — via a ProvisioningRequest — to atomically scale up the pool BEFORE
+#      the workload is admitted. The workload only starts once the nodes exist.
+#
+#   2. A ClusterQueue references that AdmissionCheck, so every workload routed
+#      through the queue goes through the provisioning gate first.
+#
+# provisioningClassName `best-effort-atomic-scale-up.autoscaling.x-k8s.io` tells
+# CAS to add all the requested capacity as a single atomic increase (all-or-
+# nothing), which is what batch/gang workloads want.
+#
+# This targets an AUTOSCALING CPU pool named `scalepool` (see the README for how
+# to add it with `az aks nodepool add --enable-cluster-autoscaler`). It is an
+# independent configuration — apply it INSTEAD OF 20-/30-, not alongside them.
+#
+# Unlike the Ray configs in this directory, this one is self-contained: it
+# creates its own `cas-kueue-demo` namespace and does not use the `ray`
+# namespace, because the workload it gates is a plain batch Job, not a RayJob.
+#
+# Apply:
+#   kubectl apply -f 40-autoscale-queue.yaml
+#
+# Verify:
+#   kubectl get admissioncheck cas-provisioning
+#   kubectl get clusterqueue cas-cluster-queue
+#   kubectl -n cas-kueue-demo get localqueue cas-local-queue
+---
+# Namespace for the cluster autoscaler + Kueue demo.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cas-kueue-demo
+---
+# ResourceFlavor pinned to the autoscaling CPU pool. AKS stamps every node in a
+# pool with `agentpool: <pool-name>`, so this flavor only admits onto scalepool.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: scalepool
+spec:
+  nodeLabels:
+    agentpool: scalepool
+---
+# AdmissionCheck that delegates capacity provisioning to CAS via ProvisioningRequest.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: AdmissionCheck
+metadata:
+  name: cas-provisioning
+spec:
+  controllerName: kueue.x-k8s.io/provisioning-request
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: ProvisioningRequestConfig
+    name: cas-provreq-config
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ProvisioningRequestConfig
+metadata:
+  name: cas-provreq-config
+spec:
+  provisioningClassName: best-effort-atomic-scale-up.autoscaling.x-k8s.io
+  managedResources:
+    - cpu
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: cas-cluster-queue
+spec:
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+    - coveredResources:
+        - cpu
+        - memory
+      flavors:
+        - name: scalepool
+          resources:
+            - name: cpu
+              # Upper bound Kueue will admit before asking CAS to grow the pool.
+              # Set generously here so quota is never the limiting factor — the
+              # pool's --max-count is what actually caps the scale-up. Lower it
+              # to max-count × per-node cores (e.g. 5 × 4 = 20) if you want
+              # Kueue to enforce the ceiling too.
+              nominalQuota: "100"
+            - name: memory
+              nominalQuota: 200Gi
+  # Gate admission on the provisioning check, scoped to the scalepool flavor.
+  # This is the form the upstream Kueue provisioning guide uses.
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: cas-provisioning
+        onFlavors: [scalepool]
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: cas-local-queue
+  namespace: cas-kueue-demo
+spec:
+  clusterQueue: cas-cluster-queue

--- a/examples/kueue-and-ray-on-aks/2-kueue-queues/manifests/50-gpu-autoscale-queue.yaml
+++ b/examples/kueue-and-ray-on-aks/2-kueue-queues/manifests/50-gpu-autoscale-queue.yaml
@@ -1,0 +1,120 @@
+# GPU autoscale queue — ProvisioningRequest AdmissionCheck driving the AKS
+# cluster autoscaler for GPU capacity.
+#
+# This is the GPU counterpart to 40-autoscale-queue.yaml. The mechanism is the
+# same (Kueue asks CAS for capacity via a ProvisioningRequest before admitting
+# the workload); what changes is what is scarce.
+#
+# With CPU, over-provisioning is cheap and a half-scheduled job is merely
+# wasteful. With GPUs it is neither. A100/H100 nodes are expensive and often
+# capacity-constrained, so two properties matter:
+#
+#   1. ATOMIC scale-up. A distributed training job that gets 6 of the 8 GPUs it
+#      asked for makes no progress, but still holds those 6 GPUs. The
+#      `best-effort-atomic-scale-up` class makes CAS add the whole increment or
+#      none of it, so a gang is never half-placed.
+#
+#   2. GPU-AWARE quota. `managedResources: [nvidia.com/gpu]` tells Kueue that
+#      the GPU is the resource CAS is being asked to provision. Workloads whose
+#      podsets request no GPU skip the provisioning gate entirely rather than
+#      waiting behind it.
+#
+# Apply:
+#   kubectl apply -f 50-gpu-autoscale-queue.yaml
+#
+# Verify:
+#   kubectl get admissioncheck gpu-provisioning
+#   kubectl get clusterqueue gpu-cluster-queue
+#   kubectl -n gpu-lab get localqueue gpu-local-queue
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-lab
+---
+# ResourceFlavor pinned to the autoscaling GPU pool.
+#
+# AKS stamps every node with `agentpool: <pool-name>`, which is the most precise
+# selector — it distinguishes an A100 pool from an H100 pool in the same cluster.
+#
+# The tolerations below are applied by Kueue to admitted pods. AKS taints GPU
+# pools created with `--node-taints nvidia.com/gpu=present:NoSchedule` so that
+# CPU work cannot land on expensive GPU nodes; the flavor has to tolerate that
+# taint or nothing will ever schedule.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: gpu-a100
+spec:
+  nodeLabels:
+    agentpool: gpupool
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Equal
+      value: present
+      effect: NoSchedule
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ProvisioningRequestConfig
+metadata:
+  name: gpu-provreq-config
+spec:
+  # All-or-nothing scale-up: CAS either provisions the entire gang's worth of
+  # GPU nodes or reports failure. This is what makes multi-node training safe.
+  provisioningClassName: best-effort-atomic-scale-up.autoscaling.x-k8s.io
+  # Only GPU requests drive provisioning. A podset that asks for CPU/memory but
+  # no GPU is considered ready immediately instead of blocking on CAS.
+  managedResources:
+    - nvidia.com/gpu
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: AdmissionCheck
+metadata:
+  name: gpu-provisioning
+spec:
+  controllerName: kueue.x-k8s.io/provisioning-request
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: ProvisioningRequestConfig
+    name: gpu-provreq-config
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: gpu-cluster-queue
+spec:
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+    - coveredResources:
+        - nvidia.com/gpu
+        - cpu
+        - memory
+      flavors:
+        - name: gpu-a100
+          resources:
+            # The GPU quota is the meaningful ceiling. Size it to
+            #   max-count x GPUs-per-node
+            # e.g. a 2-node pool of Standard_ND96amsr_A100_v4 (8 GPUs each)
+            # = 16. Kueue will not admit past this even if CAS could scale
+            # further, which is your guardrail against a runaway spend.
+            - name: nvidia.com/gpu
+              nominalQuota: "16"
+            # CPU and memory are sized generously: they are along for the ride
+            # and should not be what blocks admission.
+            - name: cpu
+              nominalQuota: "200"
+            - name: memory
+              nominalQuota: 3000Gi
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: gpu-provisioning
+        onFlavors: [gpu-a100]
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: gpu-local-queue
+  namespace: gpu-lab
+spec:
+  clusterQueue: gpu-cluster-queue

--- a/examples/kueue-and-ray-on-aks/3-workloads/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/README.md
@@ -31,6 +31,11 @@ The shared base templates in [`_template/`](_template/) define the standard
 fields used by every workload. Per-example templates extend these with
 workload-specific pip packages, env vars, and resource counts.
 
+> **Exception:** [`cas-batch-job/`](cas-batch-job/) is a plain Kubernetes Job
+> (no Ray, no `envsubst`) applied directly with `kubectl apply -f`. It
+> demonstrates the cluster-autoscaler ProvisioningRequest path rather than a Ray
+> runtime, so it doesn't use the template system described here.
+
 ### Standard fields (all workloads)
 
 | Field | Value | Reason |
@@ -93,17 +98,29 @@ Ray Serve. Loads the LoRA adapter from blob storage on startup.
 - Access: `kubectl -n ray port-forward svc/${SERVICE_NAME}-serve-svc 8000:8000`
 - See [online-serving/](online-serving/)
 
+### 5. cas-batch-job/ — provision capacity on demand (cluster autoscaler)
+A plain Kubernetes batch Job (no Ray) that demonstrates the **ProvisioningRequest
+→ cluster autoscaler** path. Where the examples above admit against a fixed quota
+on an existing GPU node, this one drives the AKS cluster autoscaler to grow an
+autoscaling CPU pool *before* the Job is admitted — capacity provisioned
+just-in-time.
+
+- **CPU only** — 3 pods × 1800m on an autoscaling `scalepool`
+- Queue: `cas-local-queue` in the `cas-kueue-demo` namespace (the ProvisioningRequest-gated queue from Module 2)
+- Requires: an autoscaling `scalepool` pool
+- See [cas-batch-job/](cas-batch-job/)
+
 ## Comparison
 
-| | aurora-finetune | llm-training | batch-inference | online-serving |
-|--|--|--|--|--|
-| Kind | RayJob | RayJob | RayJob | RayService |
-| Kueue-admitted | ✓ | ✓ | ✓ | ✗ |
-| GPUs | 1 | 4 | 1 | 1 |
-| Queue label | `default` | `default` | `default` | — |
-| Deps | Aurora, torch, azure-storage-blob | LLaMA-Factory, azure-storage-blob | vLLM, azure-storage-blob | Aurora, azure-storage-blob |
-| Reads from blob | `aurora/data/` (init/truth) | `llm-pipeline/data/` (train.jsonl) | `llm-pipeline/data/` + `lora/` | `aurora/checkpoints/` (adapter) |
-| Writes to blob | `aurora/checkpoints/` | `llm-pipeline/lora/` | `llm-pipeline/inference/` | — |
+| | aurora-finetune | llm-training | batch-inference | online-serving | cas-batch-job |
+|--|--|--|--|--|--|
+| Kind | RayJob | RayJob | RayJob | RayService | Job |
+| Kueue-admitted | ✓ | ✓ | ✓ | ✗ | ✓ |
+| GPUs | 1 | 4 | 1 | 1 | 0 (CPU) |
+| Queue label | `default` | `default` | `default` | — | `cas-local-queue` |
+| Deps | Aurora, torch, azure-storage-blob | LLaMA-Factory, azure-storage-blob | vLLM, azure-storage-blob | Aurora, azure-storage-blob | none (busybox) |
+| Reads from blob | `aurora/data/` (init/truth) | `llm-pipeline/data/` (train.jsonl) | `llm-pipeline/data/` + `lora/` | `aurora/checkpoints/` (adapter) | — |
+| Writes to blob | `aurora/checkpoints/` | `llm-pipeline/lora/` | `llm-pipeline/inference/` | — | — |
 
 ## Quick start
 

--- a/examples/kueue-and-ray-on-aks/3-workloads/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/README.md
@@ -31,10 +31,11 @@ The shared base templates in [`_template/`](_template/) define the standard
 fields used by every workload. Per-example templates extend these with
 workload-specific pip packages, env vars, and resource counts.
 
-> **Exception:** [`cas-batch-job/`](cas-batch-job/) is a plain Kubernetes Job
-> (no Ray, no `envsubst`) applied directly with `kubectl apply -f`. It
-> demonstrates the cluster-autoscaler ProvisioningRequest path rather than a Ray
-> runtime, so it doesn't use the template system described here.
+> **Exception:** [`cas-batch-job/`](cas-batch-job/) and [`gpu-lab/`](gpu-lab/)
+> are plain Kubernetes Jobs (no Ray, no `envsubst`) applied directly with
+> `kubectl apply -f`. They demonstrate the cluster-autoscaler
+> ProvisioningRequest path rather than a Ray runtime, so they don't use the
+> template system described here.
 
 ### Standard fields (all workloads)
 
@@ -110,17 +111,29 @@ just-in-time.
 - Requires: an autoscaling `scalepool` pool
 - See [cas-batch-job/](cas-batch-job/)
 
+### 6. gpu-lab/ — GPU labs, end to end (cluster autoscaler)
+A three-part lab sequence applying the same ProvisioningRequest → cluster
+autoscaler path to **GPUs**, where atomic provisioning stops being a
+convenience and becomes what keeps an expensive cluster from deadlocking.
+Covers pool provisioning, hardware verification, distributed training, queue
+contention, and the DCGM/Kueue/CAS metrics to check afterwards.
+
+- **8–16 GPUs** on an autoscaling `gpupool` (scale-to-zero)
+- Queue: `gpu-local-queue` in the `gpu-lab` namespace (Module 2, `50-gpu-autoscale-queue.yaml`)
+- Requires: an autoscaling GPU pool and regional GPU quota
+- See [gpu-lab/](gpu-lab/)
+
 ## Comparison
 
-| | aurora-finetune | llm-training | batch-inference | online-serving | cas-batch-job |
-|--|--|--|--|--|--|
-| Kind | RayJob | RayJob | RayJob | RayService | Job |
-| Kueue-admitted | ✓ | ✓ | ✓ | ✗ | ✓ |
-| GPUs | 1 | 4 | 1 | 1 | 0 (CPU) |
-| Queue label | `default` | `default` | `default` | — | `cas-local-queue` |
-| Deps | Aurora, torch, azure-storage-blob | LLaMA-Factory, azure-storage-blob | vLLM, azure-storage-blob | Aurora, azure-storage-blob | none (busybox) |
-| Reads from blob | `aurora/data/` (init/truth) | `llm-pipeline/data/` (train.jsonl) | `llm-pipeline/data/` + `lora/` | `aurora/checkpoints/` (adapter) | — |
-| Writes to blob | `aurora/checkpoints/` | `llm-pipeline/lora/` | `llm-pipeline/inference/` | — | — |
+| | aurora-finetune | llm-training | batch-inference | online-serving | cas-batch-job | gpu-lab |
+|--|--|--|--|--|--|--|
+| Kind | RayJob | RayJob | RayJob | RayService | Job | Job |
+| Kueue-admitted | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ |
+| GPUs | 1 | 4 | 1 | 1 | 0 (CPU) | 8–16 |
+| Queue label | `default` | `default` | `default` | — | `cas-local-queue` | `gpu-local-queue` |
+| Deps | Aurora, torch, azure-storage-blob | LLaMA-Factory, azure-storage-blob | vLLM, azure-storage-blob | Aurora, azure-storage-blob | none (busybox) | NGC PyTorch |
+| Reads from blob | `aurora/data/` (init/truth) | `llm-pipeline/data/` (train.jsonl) | `llm-pipeline/data/` + `lora/` | `aurora/checkpoints/` (adapter) | — | — |
+| Writes to blob | `aurora/checkpoints/` | `llm-pipeline/lora/` | `llm-pipeline/inference/` | — | — | — |
 
 ## Quick start
 

--- a/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/README.md
@@ -1,0 +1,98 @@
+# cas-batch-job — provision capacity on demand with Kueue + cluster autoscaler
+
+A plain Kubernetes batch Job that demonstrates the **ProvisioningRequest → AKS
+cluster autoscaler (CAS)** path. The other Module 3 workloads admit against a
+fixed quota on an already-provisioned GPU node; this one instead asks CAS to
+*grow* an autoscaling CPU pool before the Job is admitted, so batch capacity is
+provisioned just-in-time.
+
+This isolates the Kueue↔CAS integration from the Ray runtime — it's the
+simplest way to see a *provision-first* scale-up end to end.
+
+## How it works
+
+```
+Job (suspend: true, queue-name: cas-local-queue)
+   │
+   ▼
+Kueue creates a Workload ──► AdmissionCheck cas-provisioning
+   │                              │
+   │                              ▼
+   │                        ProvisioningRequest  ──►  cluster autoscaler
+   │                              │                     atomically scales
+   │                              ▼                     up `scalepool`
+   └──── admitted once nodes exist ◄── Provisioned=True
+   │
+   ▼
+suspend flips to false → 3 pods schedule on the new nodes → Job completes
+```
+
+The atomic `best-effort-atomic-scale-up.autoscaling.x-k8s.io` provisioning class
+adds the whole capacity block at once, avoiding the half-scheduled gang problem
+where some pods land and others sit Pending.
+
+## Prerequisites
+
+- Module 1 cluster deployed and Kueue running.
+- An **autoscaling** CPU pool named `scalepool`. If your Module 1 cluster
+  doesn't have one, add it:
+  ```bash
+  az aks nodepool add \
+    --resource-group <rg> --cluster-name <cluster> \
+    --name scalepool --mode User \
+    --node-vm-size Standard_D4s_v3 \
+    --enable-cluster-autoscaler --min-count 1 --max-count 5
+  ```
+- The autoscale queue applied from Module 2:
+  ```bash
+  kubectl apply -f ../../2-kueue-queues/manifests/40-autoscale-queue.yaml
+  ```
+
+## Submit
+
+```bash
+kubectl apply -f manifests/job.yaml
+```
+
+The Job requests 3 pods at 1800m CPU each. On a pool starting at one 4-core node
+they cannot all fit, so Kueue asks CAS to scale up before admitting them.
+
+## Watch the flow
+
+```bash
+# The Job starts Suspended
+kubectl -n cas-kueue-demo get job kueue-cas-job
+
+# Kueue creates a Workload, then a ProvisioningRequest
+kubectl -n cas-kueue-demo get workloads
+kubectl -n cas-kueue-demo get provisioningrequest
+
+# CAS provisions the nodes (Provisioned=True), the pool grows
+kubectl -n cas-kueue-demo get provisioningrequest -o yaml | grep -A5 conditions
+kubectl get nodes -l agentpool=scalepool
+
+# Job runs to completion
+kubectl -n cas-kueue-demo get job kueue-cas-job -w   # COMPLETIONS 3/3
+```
+
+Expected end state:
+
+```output
+NAME            STATUS     COMPLETIONS   DURATION   AGE
+kueue-cas-job   Complete   3/3           45s        6m
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Job stays `Suspended`, no ProvisioningRequest | Wrong queue-name label | Verify `kueue.x-k8s.io/queue-name: cas-local-queue` matches the LocalQueue |
+| ProvisioningRequest created but `status.conditions` empty | Cluster autoscaler not yet processing the request | Check the autoscaler is enabled on `scalepool` and re-check after a minute |
+| `Provisioned=False` with reason `CapacityIsNotFound` | Pool can't reach the requested size — existing workloads occupy it, or the request exceeds `--max-count` | Free capacity or raise `--max-count`. CAS keeps retrying; the Job stays suspended rather than partially scheduling |
+| Pods Pending after admission | Node label mismatch | Confirm `scalepool` nodes carry `agentpool=scalepool` (`kubectl get nodes --show-labels`) |
+
+## Clean up
+
+```bash
+kubectl delete -f manifests/job.yaml
+```

--- a/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/manifests/job.yaml
+++ b/examples/kueue-and-ray-on-aks/3-workloads/cas-batch-job/manifests/job.yaml
@@ -1,0 +1,50 @@
+# A suspended batch Job routed through Kueue's autoscale queue.
+#
+# Unlike the Ray examples in this module, this is a plain Kubernetes Job — it
+# exists to demonstrate the ProvisioningRequest -> cluster autoscaler (CAS) path
+# without the Ray runtime. The Job requests more CPU than the autoscaling pool's
+# current nodes can satisfy, so Kueue's ProvisioningRequest AdmissionCheck asks
+# CAS to add nodes BEFORE admitting it. The flow:
+#
+#   suspend: true          -> Job created but no pods yet
+#   queue-name label       -> Kueue picks it up, creates a Workload
+#   AdmissionCheck         -> Kueue creates a ProvisioningRequest for CAS
+#   CAS atomic scale-up    -> scalepool grows to fit the 3 pods
+#   suspend flipped false  -> pods schedule onto the new nodes, Job runs
+#
+# 3 pods x 1800m CPU on 4-core nodes forces a scale-up beyond the single
+# starting node (~2 schedulable pods/node).
+#
+# Each pod sleeps 30s and exits, so the Job reaches Complete 3/3 and the pool
+# scales back down afterwards.
+#
+# Submit:
+#   kubectl apply -f manifests/job.yaml
+#
+# Watch the ProvisioningRequest and scale-up:
+#   kubectl -n cas-kueue-demo get provisioningrequest
+#   kubectl get nodes -l agentpool=scalepool -w
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kueue-cas-job
+  namespace: cas-kueue-demo
+  labels:
+    kueue.x-k8s.io/queue-name: cas-local-queue
+spec:
+  parallelism: 3
+  completions: 3
+  suspend: true
+  template:
+    spec:
+      nodeSelector:
+        agentpool: scalepool
+      containers:
+        - name: worker
+          image: mcr.microsoft.com/azurelinux/busybox:1.36
+          command: ["sh", "-c", "echo running on $(hostname); sleep 30"]
+          resources:
+            requests:
+              cpu: "1800m"
+              memory: "256Mi"
+      restartPolicy: Never

--- a/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/README.md
@@ -1,0 +1,482 @@
+# GPU Labs — Kueue + Cluster Autoscaler end to end
+
+A hands-on sequence for running GPU workloads on AKS with Kueue admission
+control and the cluster autoscaler. It covers the full path a customer walks:
+provisioning a GPU pool, verifying the hardware, running distributed training,
+sharing the cluster between competing jobs, and reading the metrics that tell
+you whether any of it performed.
+
+The [`cas-batch-job`](../cas-batch-job/) example demonstrates the same
+Kueue + CAS provisioning gate on CPU. These labs are the GPU version, where the
+mechanism stops being a nicety and starts being the thing that keeps an
+expensive cluster from deadlocking.
+
+## Why admission control matters more for GPUs
+
+On CPU, over-provisioning is cheap and a partially scheduled job is merely
+wasteful. On GPUs neither holds:
+
+- **Cost.** An `ND96amsr_A100_v4` node is roughly two orders of magnitude more
+  expensive per hour than a general-purpose D8. Idle GPUs are the single
+  largest source of waste in a shared AI cluster.
+- **Scarcity.** A100/H100 capacity is frequently constrained. "Scale up and see"
+  is not a reliable strategy when the capacity may not be there.
+- **All-or-nothing semantics.** A distributed training job that receives 6 of
+  the 8 GPUs it needs does not run at 75%. It runs at 0%, while holding 6 GPUs
+  nobody else can use. Two such jobs can deadlock a cluster indefinitely, each
+  waiting on capacity the other is squatting on.
+
+Kueue plus the cluster autoscaler addresses all three. Jobs are admitted only
+when their **entire** GPU request can be satisfied, and the capacity is
+provisioned atomically before the workload starts:
+
+```mermaid
+sequenceDiagram
+    participant U as You
+    participant K as Kueue
+    participant C as Cluster Autoscaler
+    participant N as GPU nodes
+
+    U->>K: submit Job (suspend: true, 8 GPUs)
+    K->>K: check ClusterQueue quota
+    K->>C: ProvisioningRequest (atomic, 8 GPUs)
+    Note over C: best-effort-atomic-scale-up<br/>all nodes or none
+    C->>N: scale up GPU pool
+    N-->>C: nodes Ready
+    C-->>K: Provisioned
+    K->>K: AdmissionCheck satisfied
+    K->>U: un-suspend Job
+    Note over U,N: pods start only now — never half-placed
+```
+
+The job consumes nothing while it waits. No pods, no partial placement, no
+GPUs held hostage.
+
+## The labs
+
+| Lab | What it teaches | GPUs |
+|-----|-----------------|------|
+| [1 — GPU verification](manifests/10-gpu-verify.yaml) | Prove the stack works: driver, CUDA compute, NCCL interconnect | 8 (1 node) |
+| [2 — Multi-node training](manifests/20-multinode-training.yaml) | Gang scheduling for distributed PyTorch DDP | 16 (2 nodes) |
+| [3 — Queue contention](manifests/30-queue-contention.yaml) | What happens when demand exceeds quota | 24 requested / 16 available |
+
+Work through them in order. Lab 1 catches hardware problems before you spend
+time on Labs 2–3.
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| AKS cluster, Kubernetes ≥ 1.33 | ProvisioningRequest support |
+| GPU node pool with autoscaling | See below |
+| Kueue ≥ v0.9 | Installed by [Module 1](../../1-infrastructure/) |
+| GPU quota in your region | `az vm list-usage --location <region>` |
+
+### Provisioning the GPU pool
+
+The labs assume an autoscaling GPU pool named `gpupool`. The pool must scale
+from zero so idle GPUs cost nothing:
+
+```bash
+az aks nodepool add \
+  --resource-group <rg> --cluster-name <cluster> \
+  --name gpupool \
+  --node-vm-size Standard_ND96amsr_A100_v4 \
+  --node-count 0 \
+  --enable-cluster-autoscaler --min-count 0 --max-count 2 \
+  --node-taints nvidia.com/gpu=present:NoSchedule \
+  --labels gpu=a100-80gb
+```
+
+Three details that matter:
+
+- **`--min-count 0`** lets the pool scale to zero between labs. This is the
+  main cost control; without it you pay for idle A100s.
+- **`--node-taints nvidia.com/gpu=present:NoSchedule`** stops CPU workloads
+  from landing on GPU nodes. The ResourceFlavor tolerates this taint so Kueue
+  workloads still schedule.
+- **`--max-count 2`** caps the blast radius. Kueue's `nominalQuota` is a second
+  ceiling; the lower of the two wins.
+
+AKS installs the NVIDIA device plugin automatically, which is what advertises
+`nvidia.com/gpu` as a schedulable resource. Confirm before starting:
+
+```bash
+kubectl get nodes -l gpu=a100-80gb \
+  -o custom-columns=NODE:.metadata.name,GPUS:.status.capacity.nvidia\\.com/gpu
+```
+
+> **Other GPU SKUs.** These labs were validated on `ND96amsr_A100_v4`
+> (8×A100 80 GB). For `NC80adis_H100_v5` (2×H100 94 GB), set `nvidia.com/gpu`
+> to `2` in the manifests and adjust `nominalQuota` accordingly. Any SKU works
+> as long as the per-pod GPU request matches what a single node provides.
+
+### Applying the queue
+
+```bash
+kubectl apply -f ../../../2-kueue-queues/manifests/50-gpu-autoscale-queue.yaml
+```
+
+This creates the `gpu-lab` namespace, a ResourceFlavor pinned to `gpupool`, the
+ProvisioningRequestConfig and AdmissionCheck that drive CAS, and a
+ClusterQueue/LocalQueue pair. Verify it is ready:
+
+```bash
+kubectl get clusterqueue gpu-cluster-queue -o wide
+kubectl get admissioncheck gpu-provisioning
+```
+
+---
+
+## Lab 1 — GPU verification
+
+Prove the GPU stack works before trusting it with a long run.
+
+```bash
+kubectl apply -f manifests/10-gpu-verify.yaml
+kubectl -n gpu-lab get workload -w      # suspended until CAS provisions
+kubectl -n gpu-lab logs -f job/gpu-verify
+```
+
+If the pool was at zero, expect several minutes before the pod starts: node
+provisioning, GPU driver installation, then a ~9 GB image pull. This is normal
+and worth knowing so you do not mistake it for a hang.
+
+The job runs three checks of increasing strength. Actual output from an
+8×A100 node:
+
+```
+1. Devices visible to this container
+0, NVIDIA A100-SXM4-80GB, 81920 MiB, 580.159.04
+... (8 devices)
+
+2. CUDA compute check
+torch sees 8 GPU(s)
+  cuda:0 NVIDIA A100-SXM4-80GB matmul ok -> -4.531e+04
+  ...
+
+3. NCCL all-reduce across all GPUs
+       size         time   algbw   busbw
+  536870912       4542.8  118.18  206.81
+ 1073741824       8210.4  130.78  228.86
+ 2147483648        16253  132.13  231.22
+# Avg bus bandwidth    : 224.991
+```
+
+**The third check is the one that earns its keep.** A node can pass
+`nvidia-smi` and still have NVLink degraded to PCIe, which silently turns
+multi-GPU training into a crawl. Bus bandwidth is how you detect it:
+
+| Observed busbw | Interpretation |
+|----------------|----------------|
+| 200+ GB/s | Healthy NVLink on 8×A100 SXM |
+| 20–50 GB/s | Falling back to PCIe — investigate before training |
+| < 10 GB/s | Interconnect problem; do not run distributed jobs |
+
+Checking this takes a minute. Discovering it three days into a training run
+does not.
+
+---
+
+## Lab 2 — Multi-node distributed training
+
+This is the lab that justifies the design: it deliberately does not fit on one
+node.
+
+```bash
+kubectl apply -f manifests/20-multinode-training.yaml
+kubectl -n gpu-lab get pods -w
+```
+
+Watch what happens on admission: **both pods appear at once, or neither does.**
+That is the atomic guarantee. Kueue does not un-suspend the Job until CAS has
+confirmed it can provision all 16 GPUs.
+
+Follow rank 0:
+
+```bash
+kubectl -n gpu-lab logs -f job/multinode-training \
+  --selector=batch.kubernetes.io/job-completion-index=0
+```
+
+Expected tail (this run is the single-node 8-GPU baseline, measured on
+`ND96amsr_A100_v4`; the 16-rank two-node run reports the same shape):
+
+```
+process group up: 8 ranks
+  step   0  loss 0.7122
+  step  10  loss 0.1163
+  step  20  loss 0.0311
+  step  30  loss 0.0108
+  step  40  loss 0.0037
+50 steps in 0.7s
+throughput: 17568.3 samples/s across 8 ranks
+per-GPU:    2196.0 samples/s
+peak GPU memory: 3.4 GB
+```
+
+Record `per-GPU samples/s` and treat the single-node figure as your baseline.
+It is the number to watch as you change GPU count: scaling from 8 to 16 GPUs
+should roughly double aggregate throughput while per-GPU throughput stays
+flat. Expect *some* per-GPU drop when you cross a node boundary, because
+gradients then travel over the network rather than NVLink. A large drop means
+the job is communication-bound, and Lab 1's busbw is the first thing to check.
+
+> **On this synthetic benchmark specifically:** the model is small and the data
+> is generated on-device, so 50 steps complete in under a second and there is
+> no input pipeline. That makes it a clean test of the distributed machinery,
+> but it also makes it unusually communication-heavy relative to real training.
+> Do not read these absolute numbers as a throughput expectation for your own
+> model — use them to confirm the ranks rendezvous, the collective completes,
+> and scaling behaves sensibly.
+
+### Seeing the gang guarantee directly
+
+The clearest demonstration is to ask for more than the cluster can provide:
+
+```bash
+kubectl -n gpu-lab patch job multinode-training --type=json \
+  -p='[{"op":"replace","path":"/spec/parallelism","value":8}]'
+```
+
+With `--max-count 2`, an 8-node request cannot be satisfied. The Workload stays
+pending with **zero pods created** — it does not grab the 2 nodes that are
+available and wait for the rest:
+
+```bash
+kubectl -n gpu-lab describe workload | grep -A5 "Conditions"
+```
+
+Without gang scheduling this is exactly where a cluster deadlocks.
+
+---
+
+## Lab 3 — Queue contention
+
+Three jobs, 24 GPUs requested, 16 available.
+
+With the default `nominalQuota: "16"` and 8 GPUs per job, A and B are admitted
+together and C waits for one of them to finish. If your pool is smaller (for
+example a single 2-GPU H100 node), lower the quota and the per-job request to
+match; the jobs then serialise one at a time and the effect is easier to see.
+
+```bash
+kubectl apply -f manifests/30-queue-contention.yaml
+kubectl -n gpu-lab get workloads -w
+```
+
+A is admitted; B and C wait. When A finishes, B is admitted. At no point do
+three jobs each hold a fraction of what they need.
+
+```bash
+kubectl -n gpu-lab get workloads -o custom-columns=\
+NAME:.metadata.name,ADMITTED:.status.conditions[?\(@.type==\"Admitted\"\)].status
+```
+
+Observed on a 2-GPU quota (one job's worth at a time):
+
+```
+NAME                     ADMITTED
+job-contention-a-78845   True
+job-contention-b-c4362   <none>
+job-contention-c-d1cd8   <none>
+```
+
+**Check the pod count while B and C are waiting** — this is the property that
+matters:
+
+```bash
+kubectl -n gpu-lab get pods
+# only contention-a's pod exists
+```
+
+B and C have created *zero* pods. They are not holding a partial allocation
+and waiting for the rest; they consume nothing at all. Kueue reports exactly
+why:
+
+```bash
+kubectl -n gpu-lab get workload <b-workload> \
+  -o jsonpath='{.status.conditions[?(@.type=="QuotaReserved")].message}'
+# couldn't assign flavors to pod set main: insufficient unused quota
+# for nvidia.com/gpu in flavor gpu-a100, 2 more needed
+```
+
+As A completes, B is admitted in its place. The admission timestamps show the
+serialisation directly:
+
+```bash
+kubectl -n gpu-lab get workloads -o custom-columns=\
+NAME:.metadata.name,ADMITTED:.status.conditions[?\(@.type==\"Admitted\"\)].lastTransitionTime
+```
+
+```
+a admitted: 2026-09-01T19:55:32Z
+b admitted: 2026-09-01T19:59:37Z    # ~4 min later, once A released its GPUs
+c admitted: <pending>               # still queued
+```
+
+Without admission control, all three would have been scheduled at once, each
+grabbing whatever GPUs it could and none making progress.
+
+---
+
+## Checking runtime performance and metrics
+
+Verifying a job ran is not the same as verifying it ran *well*. Three layers
+are worth watching.
+
+### 1. GPU utilization (DCGM)
+
+The NVIDIA GPU Operator ships `dcgm-exporter`, which is the authoritative
+source for per-GPU telemetry. If you installed the operator:
+
+```bash
+kubectl -n gpu-operator get pods -l app=nvidia-dcgm-exporter
+
+# Raw metrics from one exporter pod
+POD=$(kubectl -n gpu-operator get pod -l app=nvidia-dcgm-exporter \
+        -o jsonpath='{.items[0].metadata.name}')
+kubectl -n gpu-operator exec "$POD" -- curl -s localhost:9400/metrics \
+  | grep -E 'DCGM_FI_DEV_(GPU_UTIL|FB_USED|POWER_USAGE)'
+```
+
+The metrics that matter during a training run:
+
+| Metric | Meaning | Healthy during training |
+|--------|---------|-------------------------|
+| `DCGM_FI_DEV_GPU_UTIL` | SM occupancy (%) | 85–100% |
+| `DCGM_FI_DEV_FB_USED` | Framebuffer memory used | Well below capacity |
+| `DCGM_FI_DEV_POWER_USAGE` | Draw (W) | Near TDP under load |
+| `DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL` | NVLink traffic | Non-zero for multi-GPU |
+
+**Low `GPU_UTIL` during training is the most common and most expensive problem
+in a GPU cluster.** It usually means the data pipeline, not the GPU, is the
+bottleneck — you are paying A100 prices to wait on a dataloader. If Lab 2 shows
+utilization below ~50%, the fix is in the input pipeline, not more GPUs.
+
+For managed collection, enable Azure Monitor and scrape the exporter:
+
+```bash
+az aks update -g <rg> -n <cluster> --enable-azure-monitor-metrics
+```
+
+### 2. Kueue queue health
+
+Whether the *queue* is behaving is a separate question from whether the GPUs are:
+
+```bash
+# Live quota accounting: reserved vs admitted vs pending
+kubectl get clusterqueue gpu-cluster-queue -o jsonpath='{.status}' | jq
+
+# Why a specific workload is not admitted
+kubectl -n gpu-lab describe workload <name> | grep -A10 Conditions
+```
+
+Useful signals: a persistently high `pendingWorkloads` with GPUs sitting idle
+points at a quota that is too tight, or a ResourceFlavor whose `nodeLabels` do
+not match any node — a common and confusing misconfiguration.
+
+### 3. Autoscaler behaviour
+
+```bash
+# Did CAS act on the ProvisioningRequest?
+kubectl get provisioningrequests -A
+
+# Full decision log
+kubectl -n kube-system describe configmap cluster-autoscaler-status
+```
+
+A `ProvisioningRequest` stuck in `Pending` usually means the region genuinely
+has no capacity for the requested SKU — the request is working correctly and
+telling you something real about supply.
+
+### End-to-end timing
+
+For capacity planning, the interesting number is wall-clock from submission to
+first step. Time the phases separately:
+
+```bash
+kubectl -n gpu-lab get events --sort-by=.lastTimestamp \
+  | grep -E 'TriggeredScaleUp|Scheduled|Pulling|Pulled|Started'
+```
+
+Indicative cold-start breakdown for an A100 node from zero. These are rough
+planning figures, not measurements — they vary with region, SKU availability,
+and registry throughput, which is exactly why the command above is worth
+running on your own cluster:
+
+| Phase | Order of magnitude |
+|-------|--------------------|
+| ProvisioningRequest → node Ready | a few minutes |
+| GPU driver install | ~1–2 min |
+| Image pull (~9 GB, uncached) | a few minutes |
+| **Total to first step** | **usually under ~15 min** |
+
+If cold start dominates your job time, that is the argument for `--min-count 1`
+(keep one node warm) or for pre-pulling images — a real trade-off between
+idle cost and queue latency, and worth measuring before deciding.
+
+---
+
+## Cleanup
+
+GPU nodes are expensive; scale down as soon as you are done.
+
+```bash
+kubectl delete namespace gpu-lab
+kubectl delete clusterqueue gpu-cluster-queue
+kubectl delete admissioncheck gpu-provisioning
+kubectl delete provisioningrequestconfig gpu-provreq-config
+kubectl delete resourceflavor gpu-a100
+```
+
+With `--min-count 0` the pool drains automatically once the pods are gone
+(default scale-down delay is 10 minutes). Confirm you are back to zero:
+
+```bash
+kubectl get nodes -l gpu=a100-80gb
+az aks nodepool show -g <rg> --cluster-name <cluster> -n gpupool \
+  --query 'count' -o tsv
+```
+
+To remove the pool entirely:
+
+```bash
+az aks nodepool delete -g <rg> --cluster-name <cluster> -n gpupool
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Workload never admitted, no ProvisioningRequest | ResourceFlavor `nodeLabels` match no node; check `agentpool` value |
+| Pods pending with `untolerated taint` | Flavor missing the `nvidia.com/gpu` toleration |
+| `nvidia.com/gpu` not in node capacity | Device plugin not ready; `kubectl -n kube-system get pods \| grep nvidia` |
+| ProvisioningRequest stuck `Pending` | No regional capacity for the SKU, or pool `--max-count` too low |
+| NCCL hangs at startup | `/dev/shm` too small — the manifests mount 16 Gi for this reason |
+| Low busbw in Lab 1 | GPUs on PCIe rather than NVLink; check the VM SKU |
+
+## What has been validated
+
+Sample outputs in this README are real, not illustrative. Specifically:
+
+- **Lab 1** was run end to end on `Standard_ND96amsr_A100_v4` (8×A100 80 GB,
+  driver 580.159.04). All three checks pass; the NCCL figures are that run.
+- **Lab 2's** training script was validated on a single 8-GPU node
+  (`torchrun` rendezvous, DDP all-reduce, throughput reporting). The output
+  shown is that 8-rank run.
+- **Lab 3's** admission behaviour was validated against a live Kueue v0.18.2
+  install: quota gating, zero pods for queued workloads, and the sequential
+  handoff. The timestamps shown are from that run.
+
+Two caveats worth stating plainly:
+
+- The **2-node** path in Lab 2 exercises the same code as the validated
+  single-node run, but the cross-node rendezvous itself was not run on a
+  multi-node GPU pool. If you hit an issue, the Service DNS
+  (`publishNotReadyAddresses`) is the first thing to check.
+- Lab 3 was validated on **quota gating**. The full
+  ProvisioningRequest→CAS scale-up path additionally requires the
+  `ProvisioningRequest` CRD, which is installed on clusters where the feature
+  is enabled; without it Kueue's AdmissionCheck stays pending. Confirm with
+  `kubectl get crd provisioningrequests.autoscaling.x-k8s.io`.

--- a/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/README.md
@@ -405,13 +405,18 @@ not match any node — a common and confusing misconfiguration.
 # Did CAS act on the ProvisioningRequest?
 kubectl get provisioningrequests -A
 
-# Full decision log
+# Current autoscaler health and per-pool state
 kubectl -n kube-system describe configmap cluster-autoscaler-status
 ```
 
 A `ProvisioningRequest` stuck in `Pending` usually means the region genuinely
 has no capacity for the requested SKU — the request is working correctly and
 telling you something real about supply.
+
+For the full admission path — Workload conditions, AdmissionCheck state,
+ProvisioningRequest events, Kueue controller logs, and how to get the managed
+autoscaler's actual logs — see
+[Observability: logs and events for the admission path](#observability-logs-and-events-for-the-admission-path).
 
 ### End-to-end timing
 
@@ -438,6 +443,156 @@ running on your own cluster:
 If cold start dominates your job time, that is the argument for `--min-count 1`
 (keep one node warm) or for pre-pulling images — a real trade-off between
 idle cost and queue latency, and worth measuring before deciding.
+
+---
+
+## Observability: logs and events for the admission path
+
+The section above covers whether a job ran *well*. This one covers **why a job
+is not running at all** — the admission path from Workload to node.
+
+Work down this list in order. Each stage hands off to the next, so the first
+stage that looks wrong is where the problem is; everything below it is just
+waiting.
+
+### 1. Workload conditions
+
+The Workload is Kueue's record of your job and the single best starting point —
+its conditions say whether it is quota-blocked, check-blocked, or admitted.
+
+```bash
+# All workloads and their admission state
+kubectl -n gpu-lab get workloads
+
+# Why this one is not admitted (QuotaReserved, Admitted, Finished)
+kubectl -n gpu-lab describe workload <name> | grep -A20 Conditions
+
+# Just the message, scriptable
+kubectl -n gpu-lab get workload <name> \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}'
+```
+
+| What you see | Meaning |
+|--------------|---------|
+| No `QuotaReserved` | ClusterQueue has no room, or no flavor fits — quota problem, not capacity |
+| `QuotaReserved=True`, not `Admitted` | Quota is fine; an AdmissionCheck is holding it — go to step 2 |
+| `Admitted=True` but pods Pending | Admission succeeded; this is now a scheduling problem (taints, labels) |
+
+### 2. AdmissionCheck status
+
+If quota is reserved but the Workload is not admitted, the provisioning check is
+the gate. Its per-workload state lives on the Workload:
+
+```bash
+# State of each check for this workload: Pending / Ready / Retry / Rejected
+kubectl -n gpu-lab get workload <name> \
+  -o jsonpath='{range .status.admissionChecks[*]}{.name}{"\t"}{.state}{"\t"}{.message}{"\n"}{end}'
+
+# The check definition itself — is the controller even active?
+kubectl describe admissioncheck gpu-provisioning
+```
+
+`Pending` means Kueue is waiting on CAS (step 3). `Retry` or `Rejected` means
+provisioning failed and the message names the reason.
+
+### 3. ProvisioningRequest events
+
+This is the handoff to the autoscaler. Conditions tell you the verdict; events
+tell you the story.
+
+```bash
+kubectl -n gpu-lab get provisioningrequest
+
+# Conditions: Provisioned, CapacityAvailable, BookingExpired, Failed
+kubectl -n gpu-lab describe provisioningrequest <name>
+
+# Events only — the most useful single command here
+kubectl -n gpu-lab get events \
+  --field-selector involvedObject.kind=ProvisioningRequest \
+  --sort-by=.lastTimestamp
+```
+
+| Condition | Meaning |
+|-----------|---------|
+| `Provisioned=True` | Nodes exist; Kueue admits the Workload next |
+| `Provisioned=False`, `CapacityIsNotFound` | Region has no capacity for the SKU, or pool `--max-count` is too low |
+| `BookingExpired=True` | Capacity was provisioned but the workload did not consume it in time |
+| `Failed=True` | Terminal — the message gives the reason |
+
+### 4. Kueue controller logs
+
+When the objects above do not explain themselves, the controller says why. The
+provisioning-request reconciler is the relevant one:
+
+```bash
+kubectl -n kueue-system logs deploy/kueue-controller-manager --tail=200
+
+# Provisioning-request failures specifically
+kubectl -n kueue-system logs deploy/kueue-controller-manager \
+  | grep -i "provisioning"
+
+# Follow while you resubmit
+kubectl -n kueue-system logs deploy/kueue-controller-manager -f \
+  | grep -iE "provisioning|admissioncheck|workload"
+```
+
+A common finding here: the `ProvisioningRequest` CRD is absent, so the
+AdmissionCheck can never move off `Pending`. Confirm with
+`kubectl get crd provisioningrequests.autoscaling.x-k8s.io`.
+
+### 5. Cluster autoscaler logs and events
+
+**On AKS the cluster autoscaler runs in the managed control plane, so there is
+no pod to get logs from.** Its decisions surface three ways.
+
+In-cluster, with no setup:
+
+```bash
+# Health and per-pool state
+kubectl -n kube-system get configmap cluster-autoscaler-status -o yaml
+
+# Why a scale-up did not happen
+kubectl get events --field-selector source=cluster-autoscaler,reason=NotTriggerScaleUp
+
+# All autoscaler warnings
+kubectl get events --field-selector source=cluster-autoscaler,type=Warning
+```
+
+For the actual logs, enable the `cluster-autoscaler` category in a diagnostic
+setting ([docs](https://learn.microsoft.com/azure/aks/cluster-autoscaler#retrieve-cluster-autoscaler-logs-and-status)):
+
+```bash
+az monitor diagnostic-settings create \
+  --name aks-cas-logs \
+  --resource $(az aks show -g <rg> -n <cluster> --query id -o tsv) \
+  --workspace <log-analytics-workspace-id> \
+  --logs '[{"category":"cluster-autoscaler","enabled":true}]'
+```
+
+Then query in Log Analytics — resource-specific mode:
+
+```kusto
+AKSControlPlane
+| where Category == "cluster-autoscaler"
+| where TimeGenerated > ago(1h)
+| project TimeGenerated, Level, Message
+| order by TimeGenerated desc
+```
+
+or Azure diagnostics mode:
+
+```kusto
+AzureDiagnostics
+| where Category == "cluster-autoscaler"
+| project TimeGenerated, log_s
+```
+
+The Azure portal also surfaces **Autoscale events**, **Autoscale warnings**, and
+**Scale-up not triggered** as tiles under the cluster's **Node pools** blade.
+
+> Enable this category *before* reproducing a scale-up problem — diagnostic
+> settings are not retroactive, and a failed provisioning attempt is exactly the
+> event you will want the logs for.
 
 ---
 

--- a/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/README.md
+++ b/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/README.md
@@ -199,36 +199,59 @@ kubectl -n gpu-lab logs -f job/multinode-training \
   --selector=batch.kubernetes.io/job-completion-index=0
 ```
 
-Expected tail (this run is the single-node 8-GPU baseline, measured on
-`ND96amsr_A100_v4`; the 16-rank two-node run reports the same shape):
+Expected tail. Measured on two `ND96amsr_A100_v4` nodes, 4 GPUs each:
 
 ```
 process group up: 8 ranks
-  step   0  loss 0.7122
-  step  10  loss 0.1163
-  step  20  loss 0.0311
+  step   0  loss 0.7103
+  step  10  loss 0.1153
+  step  20  loss 0.0310
   step  30  loss 0.0108
-  step  40  loss 0.0037
-50 steps in 0.7s
-throughput: 17568.3 samples/s across 8 ranks
-per-GPU:    2196.0 samples/s
+  step  40  loss 0.0039
+50 steps in 80.8s
+throughput: 158.3 samples/s across 8 ranks
+per-GPU:    19.8 samples/s
 peak GPU memory: 3.4 GB
 ```
 
-Record `per-GPU samples/s` and treat the single-node figure as your baseline.
-It is the number to watch as you change GPU count: scaling from 8 to 16 GPUs
-should roughly double aggregate throughput while per-GPU throughput stays
-flat. Expect *some* per-GPU drop when you cross a node boundary, because
-gradients then travel over the network rather than NVLink. A large drop means
-the job is communication-bound, and Lab 1's busbw is the first thing to check.
+Record `per-GPU samples/s`. It is the number that exposes communication cost,
+and comparing it against a single-node run is the most useful thing this lab
+does. The same 8 ranks on **one** node report:
+
+```
+50 steps in 0.7s
+throughput: 17568.3 samples/s across 8 ranks
+per-GPU:    2196.0 samples/s
+```
+
+That is a ~110x difference for identical work, and it is not a mistake — it is
+the lesson. Within a node the gradient all-reduce crosses NVLink at ~225 GB/s
+(Lab 1). Across nodes it crosses whatever network NCCL can find, and on a
+cluster without RDMA configured that is TCP over the pod network:
+
+```bash
+kubectl -n gpu-lab logs job/multinode-training | grep -E "NET/IB|Using network"
+```
+
+```
+NCCL INFO NET/IB : No device found.
+NCCL INFO NET/Socket : Using [0]eth0
+NCCL INFO Using network Socket
+```
+
+`Using network Socket` is the finding. On an InfiniBand-enabled SKU with the
+RDMA plugin installed you would instead see `NET/IB` with an active device, and
+the cross-node penalty largely disappears. **Check this line before blaming
+your model for poor multi-node scaling** — it is the difference between a
+communication-bound job and a compute-bound one.
 
 > **On this synthetic benchmark specifically:** the model is small and the data
-> is generated on-device, so 50 steps complete in under a second and there is
-> no input pipeline. That makes it a clean test of the distributed machinery,
-> but it also makes it unusually communication-heavy relative to real training.
-> Do not read these absolute numbers as a throughput expectation for your own
-> model — use them to confirm the ranks rendezvous, the collective completes,
-> and scaling behaves sensibly.
+> is generated on-device, so each step is almost pure communication with very
+> little compute to overlap it against. That makes the socket-fallback penalty
+> look far more dramatic here than it would on a real training job, where
+> larger batches and real compute hide much of the transfer. Use these numbers
+> to confirm the ranks rendezvous and to compare transports — not as a
+> throughput expectation for your own model.
 
 ### Seeing the gang guarantee directly
 
@@ -455,6 +478,9 @@ az aks nodepool delete -g <rg> --cluster-name <cluster> -n gpupool
 | ProvisioningRequest stuck `Pending` | No regional capacity for the SKU, or pool `--max-count` too low |
 | NCCL hangs at startup | `/dev/shm` too small — the manifests mount 16 Gi for this reason |
 | Low busbw in Lab 1 | GPUs on PCIe rather than NVLink; check the VM SKU |
+| Lab 2 much slower than single-node | NCCL fell back to TCP; check for `Using network Socket` in the logs and whether RDMA/IB is available on the SKU |
+| Rank 1 Pending, rank 0 Running | Not enough free GPUs for a whole rank — another workload may hold GPUs on the node; `kubectl describe node <n> \| grep nvidia.com/gpu` |
+| `AllocationFailed` when scaling the pool | The region is out of capacity for that GPU SKU; try another region or SKU |
 
 ## What has been validated
 
@@ -462,21 +488,28 @@ Sample outputs in this README are real, not illustrative. Specifically:
 
 - **Lab 1** was run end to end on `Standard_ND96amsr_A100_v4` (8×A100 80 GB,
   driver 580.159.04). All three checks pass; the NCCL figures are that run.
-- **Lab 2's** training script was validated on a single 8-GPU node
-  (`torchrun` rendezvous, DDP all-reduce, throughput reporting). The output
-  shown is that 8-rank run.
+- **Lab 2** was run both single-node (8 ranks, one node) and **cross-node**
+  (8 ranks over two `ND96amsr_A100_v4` nodes, 4 GPUs each). The Job completed
+  2/2, the DNS wait loop retried four times before rank 0 resolved, and both
+  throughput figures are from those runs.
 - **Lab 3's** admission behaviour was validated against a live Kueue v0.18.2
   install: quota gating, zero pods for queued workloads, and the sequential
   handoff. The timestamps shown are from that run.
 
 Two caveats worth stating plainly:
 
-- The **2-node** path in Lab 2 exercises the same code as the validated
-  single-node run, but the cross-node rendezvous itself was not run on a
-  multi-node GPU pool. If you hit an issue, the Service DNS
-  (`publishNotReadyAddresses`) is the first thing to check.
+- The cross-node run used **4 GPUs per node rather than 8**, because another
+  tenant held a GPU on one of the shared test nodes. The manifest as written
+  requests 8; adjust to match your pool.
 - Lab 3 was validated on **quota gating**. The full
   ProvisioningRequest→CAS scale-up path additionally requires the
   `ProvisioningRequest` CRD, which is installed on clusters where the feature
   is enabled; without it Kueue's AdmissionCheck stays pending. Confirm with
   `kubectl get crd provisioningrequests.autoscaling.x-k8s.io`.
+
+One more note from testing, since it is the kind of thing these labs exist to
+surface: scaling the A100 pool in `centraluseuap` failed with
+`AllocationFailed` — the region had no capacity for the SKU. That is not a
+configuration error, and it is precisely why the provisioning gate matters. A
+ProvisioningRequest that stays `Pending` is reporting a real constraint on
+supply rather than misbehaving.

--- a/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/manifests/10-gpu-verify.yaml
+++ b/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/manifests/10-gpu-verify.yaml
@@ -1,0 +1,107 @@
+# Lab 1 — Single-node GPU verification.
+#
+# Goal: prove the GPU stack works end to end before you trust it with a real
+# training run. This job asks Kueue for all 8 GPUs on one node, which forces a
+# ProvisioningRequest through CAS, then reports what it actually got.
+#
+# Three checks, in increasing order of strength:
+#
+#   1. nvidia-smi          — driver + device plugin are wired up
+#   2. CUDA compute        — the GPU can actually run a kernel
+#   3. NCCL all-reduce     — the interconnect between GPUs performs correctly
+#
+# Step 3 is the one that catches the expensive failures. A node can pass
+# nvidia-smi and still have NVLink degraded to PCIe, which silently turns a
+# multi-GPU training job into a crawl. Bus bandwidth is the number that tells
+# you, and you want to check it BEFORE queueing a multi-day run.
+#
+# Submit:
+#   kubectl apply -f 10-gpu-verify.yaml
+#
+# Watch admission (stays Suspended until CAS provisions):
+#   kubectl -n gpu-lab get workload -w
+#
+# Read the results:
+#   kubectl -n gpu-lab logs job/gpu-verify
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gpu-verify
+  namespace: gpu-lab
+  labels:
+    # Routes the Job through Kueue. Without this label Kueue ignores the Job
+    # and it schedules directly, bypassing the provisioning gate.
+    kueue.x-k8s.io/queue-name: gpu-local-queue
+spec:
+  # Kueue requires suspend: true. It flips this to false on admission, which is
+  # the whole point: the pod is not created until the GPUs exist.
+  suspend: true
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: verify
+          # NGC PyTorch ships nvidia-smi, a CUDA runtime, and the NCCL test
+          # binaries in one image, so all three checks run without a build step.
+          # It is large (~9 GB); the first pull onto a fresh node takes several
+          # minutes, which is normal and worth knowing before you think it hung.
+          image: nvcr.io/nvidia/pytorch:24.12-py3
+          command:
+            - bash
+            - -lc
+            - |
+              set -euo pipefail
+
+              echo "=============================================="
+              echo "1. Devices visible to this container"
+              echo "=============================================="
+              nvidia-smi --query-gpu=index,name,memory.total,driver_version \
+                         --format=csv
+
+              echo
+              echo "=============================================="
+              echo "2. CUDA compute check"
+              echo "=============================================="
+              python -c "
+              import torch
+              assert torch.cuda.is_available(), 'CUDA not available'
+              n = torch.cuda.device_count()
+              print(f'torch sees {n} GPU(s)')
+              # Real work on each device, not just a capability query.
+              for i in range(n):
+                  x = torch.randn(8192, 8192, device=f'cuda:{i}')
+                  torch.cuda.synchronize(i)
+                  print(f'  cuda:{i} {torch.cuda.get_device_name(i)} matmul ok '
+                        f'-> {float((x @ x).sum()):.3e}')
+              "
+
+              echo
+              echo "=============================================="
+              echo "3. NCCL all-reduce across all GPUs"
+              echo "=============================================="
+              # -g 8 = 8 GPUs in one process group. busbw is the number that
+              # matters: on 8xA100 SXM (NVLink) expect roughly 200+ GB/s.
+              # If you see single-digit or low-tens GB/s, the GPUs are talking
+              # over PCIe instead of NVLink -- investigate before training.
+              all_reduce_perf -b 512M -e 2G -f 2 -g 8
+
+              echo
+              echo "All checks passed."
+          resources:
+            limits:
+              # Whole-node request. This is what triggers the atomic scale-up:
+              # no existing node can satisfy it unless a full GPU node is free.
+              nvidia.com/gpu: 8
+          volumeMounts:
+            # NCCL and CUDA use shared memory for inter-process transfers. The
+            # default 64 MB /dev/shm is a classic cause of cryptic NCCL hangs.
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi

--- a/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/manifests/20-multinode-training.yaml
+++ b/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/manifests/20-multinode-training.yaml
@@ -1,0 +1,173 @@
+# Lab 2 — Multi-node distributed training with gang scheduling.
+#
+# This is the lab that justifies the whole Kueue + CAS design. Labs 1 and 3 fit
+# on one node; this one deliberately does not.
+#
+# A distributed training job is all-or-nothing. Every rank must join the
+# collective before step 1 begins, so a job that receives 2 of the 4 nodes it
+# needs does not run at 50% -- it runs at 0%, while holding 2 nodes' worth of
+# GPUs that nobody else can use. Two of these half-placed jobs can deadlock a
+# cluster indefinitely, each waiting for capacity the other is squatting on.
+#
+# The provisioning gate prevents that. Kueue does not admit this Job until CAS
+# has confirmed it can provision ALL the requested nodes as a single atomic
+# increment. Until then the Job stays suspended and consumes nothing.
+#
+# What it actually runs: a PyTorch DDP training loop over synthetic data. The
+# model is deliberately small and the data synthetic, so the lab exercises the
+# distributed machinery -- rendezvous, gradient all-reduce, throughput -- and
+# not a dataset download.
+#
+# Submit:
+#   kubectl apply -f 20-multinode-training.yaml
+#
+# Watch the gang get admitted together (all pods appear at once, or none do):
+#   kubectl -n gpu-lab get pods -w
+#
+# Follow rank 0:
+#   kubectl -n gpu-lab logs -f job/multinode-training --selector=batch.kubernetes.io/job-completion-index=0
+---
+# Headless Service gives the pods stable DNS names for rendezvous. Indexed Jobs
+# get predictable hostnames (<job>-<index>.<service>), which is what lets rank 0
+# advertise an address the other ranks can resolve before they have all started.
+apiVersion: v1
+kind: Service
+metadata:
+  name: multinode-training
+  namespace: gpu-lab
+spec:
+  clusterIP: None
+  # Ranks must resolve each other during startup, before any pod is Ready.
+  publishNotReadyAddresses: true
+  selector:
+    job-name: multinode-training
+  ports:
+    - name: rendezvous
+      port: 29500
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: multinode-training
+  namespace: gpu-lab
+  labels:
+    kueue.x-k8s.io/queue-name: gpu-local-queue
+spec:
+  suspend: true
+  backoffLimit: 0
+  # Indexed completion gives each pod a stable, unique index that maps directly
+  # onto a distributed rank.
+  completionMode: Indexed
+  completions: 2
+  parallelism: 2
+  template:
+    spec:
+      restartPolicy: Never
+      subdomain: multinode-training
+      containers:
+        - name: trainer
+          image: nvcr.io/nvidia/pytorch:24.12-py3
+          env:
+            - name: NNODES
+              value: "2"
+            - name: GPUS_PER_NODE
+              value: "8"
+            - name: MASTER_ADDR
+              value: multinode-training-0.multinode-training
+            - name: MASTER_PORT
+              value: "29500"
+            - name: JOB_INDEX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
+            # Surfaces NCCL's chosen transport in the logs. Worth keeping on in
+            # a lab: it is how you confirm the ranks are using the fast path.
+            - name: NCCL_DEBUG
+              value: INFO
+          command:
+            - bash
+            - -lc
+            - |
+              set -euo pipefail
+              echo "Rank ${JOB_INDEX} of ${NNODES}, master=${MASTER_ADDR}:${MASTER_PORT}"
+
+              # Wait for rank 0's DNS to resolve. Pods start in parallel, so on
+              # a cold scale-up the non-zero ranks routinely come up first.
+              until getent hosts "${MASTER_ADDR}" >/dev/null 2>&1; do
+                echo "waiting for ${MASTER_ADDR}..."
+                sleep 5
+              done
+
+              cat >/tmp/train.py <<'PY'
+              import os, time, torch, torch.distributed as dist
+              import torch.nn as nn
+              from torch.nn.parallel import DistributedDataParallel as DDP
+
+              dist.init_process_group("nccl")
+              rank, world = dist.get_rank(), dist.get_world_size()
+              local = int(os.environ["LOCAL_RANK"])
+              torch.cuda.set_device(local)
+
+              if rank == 0:
+                  print(f"process group up: {world} ranks", flush=True)
+
+              # Large enough that the gradient all-reduce is a real test of the
+              # interconnect rather than pure launch overhead.
+              model = nn.Sequential(
+                  nn.Linear(8192, 8192), nn.ReLU(),
+                  nn.Linear(8192, 8192), nn.ReLU(),
+                  nn.Linear(8192, 1024),
+              ).cuda()
+              model = DDP(model, device_ids=[local])
+              opt = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+              batch, steps = 32, 50
+              x = torch.randn(batch, 8192, device="cuda")
+              y = torch.randn(batch, 1024, device="cuda")
+
+              # Warm up before timing: the first steps include CUDA context
+              # setup and NCCL channel negotiation, which are not steady state.
+              for _ in range(5):
+                  opt.zero_grad(); nn.functional.mse_loss(model(x), y).backward(); opt.step()
+              torch.cuda.synchronize(); dist.barrier()
+
+              t0 = time.time()
+              for i in range(steps):
+                  opt.zero_grad()
+                  loss = nn.functional.mse_loss(model(x), y)
+                  loss.backward()
+                  opt.step()
+                  if rank == 0 and i % 10 == 0:
+                      print(f"  step {i:3d}  loss {loss.item():.4f}", flush=True)
+              torch.cuda.synchronize()
+              dt = time.time() - t0
+
+              if rank == 0:
+                  total = batch * world * steps
+                  print(f"\n{steps} steps in {dt:.1f}s")
+                  print(f"throughput: {total/dt:.1f} samples/s across {world} ranks")
+                  print(f"per-GPU:    {total/dt/world:.1f} samples/s")
+                  mem = torch.cuda.max_memory_allocated() / 1e9
+                  print(f"peak GPU memory: {mem:.1f} GB")
+
+              dist.destroy_process_group()
+              PY
+
+              torchrun \
+                --nnodes="${NNODES}" \
+                --nproc_per_node="${GPUS_PER_NODE}" \
+                --node_rank="${JOB_INDEX}" \
+                --master_addr="${MASTER_ADDR}" \
+                --master_port="${MASTER_PORT}" \
+                /tmp/train.py
+          resources:
+            limits:
+              nvidia.com/gpu: 8
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi

--- a/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/manifests/30-queue-contention.yaml
+++ b/examples/kueue-and-ray-on-aks/3-workloads/gpu-lab/manifests/30-queue-contention.yaml
@@ -1,0 +1,131 @@
+# Lab 3 — Queue contention and GPU sharing.
+#
+# The first two labs each ran alone. Real shared clusters do not work that way,
+# and this lab shows what Kueue does when demand exceeds supply.
+#
+# It submits three jobs at once, together asking for more GPUs than the quota
+# allows. You should see them admitted in sequence rather than all at once, and
+# -- the important part -- you should NOT see three half-started jobs each
+# holding a fraction of what it needs.
+#
+# This is the behaviour that makes a shared GPU cluster usable. Without
+# admission control, three simultaneous submissions race for the same GPUs and
+# can all end up stuck. With it, jobs queue and drain in order.
+#
+# Submit all three:
+#   kubectl apply -f 30-queue-contention.yaml
+#
+# Watch admission order:
+#   kubectl -n gpu-lab get workloads -w
+#
+# See who is admitted vs pending, and why:
+#   kubectl -n gpu-lab get workloads -o custom-columns=\
+#   NAME:.metadata.name,ADMITTED:.status.conditions[?(@.type=="Admitted")].status,QUEUE:.spec.queueName
+#
+# Inspect the queue's own accounting:
+#   kubectl get clusterqueue gpu-cluster-queue -o yaml | yq '.status'
+---
+# Job A — 8 GPUs. Submitted first, expected to be admitted first.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: contention-a
+  namespace: gpu-lab
+  labels:
+    kueue.x-k8s.io/queue-name: gpu-local-queue
+spec:
+  suspend: true
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: work
+          image: nvcr.io/nvidia/pytorch:24.12-py3
+          command:
+            - bash
+            - -lc
+            - |
+              echo "[A] admitted at $(date -Is) on $(hostname)"
+              nvidia-smi --query-gpu=index,name --format=csv,noheader
+              # Occupy the GPUs briefly so the queue has something to serialise.
+              python -c "
+              import torch, time
+              n = torch.cuda.device_count()
+              print(f'[A] holding {n} GPU(s) for 120s')
+              bufs = [torch.randn(4096, 4096, device=f'cuda:{i}') for i in range(n)]
+              t = time.time()
+              while time.time() - t < 120:
+                  for b in bufs: b @ b
+              print('[A] done')
+              "
+          resources:
+            limits:
+              nvidia.com/gpu: 8
+---
+# Job B — 8 GPUs. Together with A this exactly consumes a 16-GPU quota.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: contention-b
+  namespace: gpu-lab
+  labels:
+    kueue.x-k8s.io/queue-name: gpu-local-queue
+spec:
+  suspend: true
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: work
+          image: nvcr.io/nvidia/pytorch:24.12-py3
+          command:
+            - bash
+            - -lc
+            - |
+              echo "[B] admitted at $(date -Is) on $(hostname)"
+              nvidia-smi --query-gpu=index,name --format=csv,noheader
+              python -c "
+              import torch, time
+              n = torch.cuda.device_count()
+              print(f'[B] holding {n} GPU(s) for 120s')
+              bufs = [torch.randn(4096, 4096, device=f'cuda:{i}') for i in range(n)]
+              t = time.time()
+              while time.time() - t < 120:
+                  for b in bufs: b @ b
+              print('[B] done')
+              "
+          resources:
+            limits:
+              nvidia.com/gpu: 8
+---
+# Job C — 8 GPUs. Exceeds the remaining quota, so it MUST wait for A or B to
+# finish. This is the one to watch: it should stay suspended with zero pods,
+# not start partially.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: contention-c
+  namespace: gpu-lab
+  labels:
+    kueue.x-k8s.io/queue-name: gpu-local-queue
+spec:
+  suspend: true
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: work
+          image: nvcr.io/nvidia/pytorch:24.12-py3
+          command:
+            - bash
+            - -lc
+            - |
+              echo "[C] admitted at $(date -Is) -- note how much later than A/B"
+              nvidia-smi --query-gpu=index,name --format=csv,noheader
+              echo "[C] done"
+          resources:
+            limits:
+              nvidia.com/gpu: 8

--- a/examples/kueue-and-ray-on-aks/README.md
+++ b/examples/kueue-and-ray-on-aks/README.md
@@ -73,8 +73,8 @@ keys in the manifests.
 | Module | Directory | What you'll do |
 |--------|-----------|----------------|
 | 1 — Infrastructure | [`1-infrastructure/`](1-infrastructure/) | Provision the AKS cluster, KubeRay + Kueue operators, Blob storage, workload identity, and pre-staged datasets with one `terraform apply` |
-| 2 — Kueue Queues | [`2-kueue-queues/`](2-kueue-queues/) | Apply ResourceFlavors and ClusterQueues — a single backpressure queue or two teams sharing a cohort with borrowing |
-| 3 — Workloads | [`3-workloads/`](3-workloads/) | Submit Ray examples: Aurora fine-tune, LLM training, batch inference (RayJob), and online serving (RayService) |
+| 2 — Kueue Queues | [`2-kueue-queues/`](2-kueue-queues/) | Apply ResourceFlavors and ClusterQueues — a single backpressure queue, two teams sharing a cohort with borrowing, or an autoscale queue that drives the cluster autoscaler on demand |
+| 3 — Workloads | [`3-workloads/`](3-workloads/) | Submit Ray examples: Aurora fine-tune, LLM training, batch inference (RayJob), online serving (RayService), and a cluster-autoscaler batch Job |
 
 Work through them in order — each module assumes the previous one is in place.
 
@@ -84,6 +84,7 @@ The workloads in Module 3:
 - **[LLM training](3-workloads/llm-training/)** — Distributed Qwen2.5-7B LoRA fine-tune with Ray Train and LLaMA-Factory (RayJob)
 - **[Batch inference](3-workloads/batch-inference/)** — Parallel inference over a dataset using Ray Data and ActorPool (RayJob)
 - **[Online serving](3-workloads/online-serving/)** — Aurora model served behind a stable HTTP endpoint with Ray Serve (RayService)
+- **[CAS batch job](3-workloads/cas-batch-job/)** — a plain batch Job that provisions capacity on demand via a Kueue ProvisioningRequest driving the AKS cluster autoscaler
 
 ## Prerequisites
 

--- a/examples/kueue-and-ray-on-aks/README.md
+++ b/examples/kueue-and-ray-on-aks/README.md
@@ -85,6 +85,7 @@ The workloads in Module 3:
 - **[Batch inference](3-workloads/batch-inference/)** — Parallel inference over a dataset using Ray Data and ActorPool (RayJob)
 - **[Online serving](3-workloads/online-serving/)** — Aurora model served behind a stable HTTP endpoint with Ray Serve (RayService)
 - **[CAS batch job](3-workloads/cas-batch-job/)** — a plain batch Job that provisions capacity on demand via a Kueue ProvisioningRequest driving the AKS cluster autoscaler
+- **[GPU labs](3-workloads/gpu-lab/)** — end-to-end GPU walkthrough: provision an autoscaling GPU pool, verify the hardware (driver, CUDA, NCCL), run multi-node distributed training with gang scheduling, exercise queue contention, and check DCGM/Kueue/CAS metrics
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Adds a `gpu-lab` module to `examples/kueue-and-ray-on-aks/` — a three-part lab sequence that takes a customer from GPU pool provisioning through hardware verification, multi-node distributed training, and queue contention, plus the metrics to check afterwards.

This extends #5867 (CPU-only ProvisioningRequest example) to GPUs, where atomic provisioning stops being a convenience and becomes what keeps an expensive cluster from deadlocking.

> **Stacked on #5867.** Until that merges, the diff here includes its commit.

New/changed:
- `2-kueue-queues/manifests/50-gpu-autoscale-queue.yaml` — GPU ResourceFlavor (with the `nvidia.com/gpu=present:NoSchedule` toleration AKS puts on GPU pools), ProvisioningRequestConfig with `managedResources: [nvidia.com/gpu]`, AdmissionCheck, ClusterQueue, LocalQueue
- `3-workloads/gpu-lab/` — README + three lab manifests (hardware verify, multi-node torchrun DDP, queue contention)
- Parent README updates in the example root, module 2, and module 3

## Validated on real hardware

Run against A100 80GB pools; measured output is in the README rather than illustrative numbers.

- **Lab 1** (8×A100, one node): nvidia-smi, per-device torch matmul, and NCCL `all_reduce_perf` all pass — `Avg bus bandwidth : 224.991 GB/s` (NVLink-class)
- **Lab 2 single-node** (8 ranks): `50 steps in 0.7s`, `17568.3 samples/s`
- **Lab 2 cross-node** (2 nodes × 4 GPUs): completes, but `19.8 samples/s` per GPU — ~110× slower. Cause: `NCCL INFO NET/IB : No device found` → `Using network Socket`, i.e. TCP over eth0 instead of RDMA. The README makes this the central teaching point: reading the NCCL transport line is how you tell a working multi-node job from a working-but-pointless one.
- **Lab 3** (Kueue v0.18.2): A admitted, B admitted 4m later, C stayed suspended with **zero** pods — `insufficient unused quota for nvidia.com/gpu in flavor gpu-a100, 2 more needed`

## Caveats, documented in the README

- The cross-node run used 4 GPUs/node rather than 8 because another tenant held a GPU on one node.
- Lab 3 was validated on quota gating only — the ProvisioningRequest CRD is absent from both test clusters, so the CAS scale-up path there is described, not measured. The CPU equivalent is exercised in #5867.
- An A100 scale-up in centraluseuap hit `AllocationFailed` (pinned availability set out of capacity). Kept in the README as a real illustration of why GPU capacity is worth gating.

## Test plan

- [x] Lab 1 run on an 8×A100 node
- [x] Lab 2 run single-node and cross-node
- [x] Lab 3 run against a real Kueue ClusterQueue
- [x] All test resources cleaned up; autoscaling pool reverted