### PR TITLE
cost-analysis-export: Fail merge when AKS or cost imports are empty

### DIFF
--- a/examples/cost-analysis-export/main.go
+++ b/examples/cost-analysis-export/main.go
@@ -330,6 +330,7 @@ func (a *App) importAKSData(ctx context.Context) error {
 		Prefix: &a.Config.AzureStorageAKSDataPrefix,
 	})
 
+	matched := 0
 	filesProcessed := 0
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
@@ -348,6 +349,7 @@ func (a *App) importAKSData(ctx context.Context) error {
 				continue
 			}
 
+			matched++
 			if err := a.processAKSBlob(ctx, *blob.Name); err != nil {
 				slog.Error("failed to process AKS blob", "name", *blob.Name, "error", err)
 				continue
@@ -357,7 +359,11 @@ func (a *App) importAKSData(ctx context.Context) error {
 	}
 
 	if filesProcessed == 0 {
-		return fmt.Errorf("no AKS export files found under prefix %q (expected %sexport-*.csv)", a.Config.AzureStorageAKSDataPrefix, a.Config.AzureStorageAKSDataPrefix)
+		prefix := a.Config.AzureStorageAKSDataPrefix
+		if matched == 0 {
+			return fmt.Errorf("no AKS export files found under prefix %q (expected %sexport-*.csv or %sexport-*.csv.gz)", prefix, prefix, prefix)
+		}
+		return fmt.Errorf("no AKS export files imported under prefix %q (%d matching blob(s) failed)", prefix, matched)
 	}
 	slog.Info("processed AKS export files", "count", filesProcessed)
 	return nil
@@ -373,6 +379,7 @@ func (a *App) importCostManagementData(ctx context.Context) error {
 		Prefix: &a.Config.AzureStorageCostExportPrefix,
 	})
 
+	matched := 0
 	filesProcessed := 0
 
 	for pager.More() {
@@ -392,6 +399,7 @@ func (a *App) importCostManagementData(ctx context.Context) error {
 				continue
 			}
 
+			matched++
 			if err := a.processCostManagementBlob(ctx, *blob.Name); err != nil {
 				slog.Error("failed to process cost management blob", "name", *blob.Name, "error", err)
 				continue
@@ -401,7 +409,11 @@ func (a *App) importCostManagementData(ctx context.Context) error {
 	}
 
 	if filesProcessed == 0 {
-		return fmt.Errorf("no cost management files found under prefix %q", a.Config.AzureStorageCostExportPrefix)
+		prefix := a.Config.AzureStorageCostExportPrefix
+		if matched == 0 {
+			return fmt.Errorf("no cost management files found under prefix %q (expected *.csv or *.csv.gz)", prefix)
+		}
+		return fmt.Errorf("no cost management files imported under prefix %q (%d matching blob(s) failed)", prefix, matched)
 	}
 	slog.Info("processed cost management files", "count", filesProcessed)
 	return nil

--- a/examples/cost-analysis-export/main.go
+++ b/examples/cost-analysis-export/main.go
@@ -357,11 +357,9 @@ func (a *App) importAKSData(ctx context.Context) error {
 	}
 
 	if filesProcessed == 0 {
-		slog.Error("no AKS export files found", "prefix", a.Config.AzureStorageAKSDataPrefix, "expected_pattern", a.Config.AzureStorageAKSDataPrefix+"export-*.csv")
-	} else {
-		slog.Info("processed AKS export files", "count", filesProcessed)
+		return fmt.Errorf("no AKS export files found under prefix %q (expected %sexport-*.csv)", a.Config.AzureStorageAKSDataPrefix, a.Config.AzureStorageAKSDataPrefix)
 	}
-
+	slog.Info("processed AKS export files", "count", filesProcessed)
 	return nil
 }
 
@@ -403,11 +401,9 @@ func (a *App) importCostManagementData(ctx context.Context) error {
 	}
 
 	if filesProcessed == 0 {
-		slog.Error("no cost management files found to process", "prefix", a.Config.AzureStorageCostExportPrefix)
-	} else {
-		slog.Info("processed cost management files", "count", filesProcessed)
+		return fmt.Errorf("no cost management files found under prefix %q", a.Config.AzureStorageCostExportPrefix)
 	}
-
+	slog.Info("processed cost management files", "count", filesProcessed)
 	return nil
 }
 
@@ -511,7 +507,7 @@ func (a *App) ImportCSV(ctx context.Context, data io.Reader, tableName string) e
 				standardHeader := []string{"SubscriptionGuid", "ResourceGroup", "ResourceLocation", "UsageDateTime", "MeterCategory", "MeterSubCategory", "MeterId", "MeterName", "MeterRegion", "UsageQuantity", "ResourceRate", "PreTaxCost", "ConsumedService", "ResourceType", "InstanceId", "Tags", "OfferId", "AdditionalInfo", "ServiceInfo1", "ServiceInfo2", "ServiceName", "ServiceTier", "Currency", "UnitOfMeasure"}
 				return a.createTableFromHeader(ctx, tableName, standardHeader)
 			}
-			return nil
+			return fmt.Errorf("empty CSV for table %s", tableName)
 		}
 		return fmt.Errorf("reading header: %w", err)
 	}

--- a/examples/cost-analysis-export/main_test.go
+++ b/examples/cost-analysis-export/main_test.go
@@ -453,7 +453,8 @@ func TestApp_Merge_NoAKSExportFiles(t *testing.T) {
 	require.NoError(t, err)
 	err = app.Merge(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no AKS export files")
+	assert.Contains(t, err.Error(), "no AKS export files found")
+	assert.Contains(t, err.Error(), ".csv.gz")
 }
 
 func TestApp_Merge_EmptyAKSExport(t *testing.T) {
@@ -475,7 +476,8 @@ func TestApp_Merge_EmptyAKSExport(t *testing.T) {
 	require.NoError(t, err)
 	err = app.Merge(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no AKS export files")
+	assert.Contains(t, err.Error(), "no AKS export files imported")
+	assert.Contains(t, err.Error(), "1 matching blob")
 }
 
 func TestApp_Merge_NoCostManagementFiles(t *testing.T) {
@@ -496,7 +498,8 @@ func TestApp_Merge_NoCostManagementFiles(t *testing.T) {
 	require.NoError(t, err)
 	err = app.Merge(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no cost management files")
+	assert.Contains(t, err.Error(), "no cost management files found")
+	assert.Contains(t, err.Error(), ".csv.gz")
 }
 
 func openTestDB(t *testing.T) *sql.DB {

--- a/examples/cost-analysis-export/main_test.go
+++ b/examples/cost-analysis-export/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"net/http"
@@ -416,6 +417,96 @@ test-guid,rg,westus,2025-06-18,Virtual Machines,Standard,meter-id,VM,westus,1,10
 			}
 		})
 	}
+}
+
+func TestImportCSV_EmptyAKSSplitsReturnsError(t *testing.T) {
+	app := &App{DB: openTestDB(t)}
+	err := app.ImportCSV(context.Background(), strings.NewReader(""), "aks_splits")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aks_splits")
+}
+
+func TestImportCSV_EmptyCostManagementCreatesTable(t *testing.T) {
+	app := &App{DB: openTestDB(t)}
+	err := app.ImportCSV(context.Background(), strings.NewReader(""), "cost_management")
+	require.NoError(t, err)
+	cols, err := app.getTableColumns(context.Background(), "cost_management")
+	require.NoError(t, err)
+	assert.Contains(t, cols, "SubscriptionGuid")
+}
+
+func TestApp_Merge_NoAKSExportFiles(t *testing.T) {
+	date := time.Date(2025, 6, 18, 0, 0, 0, 0, time.UTC)
+	cfg := Config{
+		AzureStorageConnectionString: SetupAzuriteContainer(t, "test-no-aks", map[string][]byte{
+			"cost-management/file1.csv": []byte("SubscriptionGuid,ResourceGroup,ResourceLocation,UsageDateTime,MeterCategory,MeterSubCategory,MeterId,MeterName,MeterRegion,UsageQuantity,ResourceRate,PreTaxCost,ConsumedService,ResourceType,InstanceId,Tags,OfferId,AdditionalInfo,ServiceInfo1,ServiceInfo2,ServiceName,ServiceTier,Currency,UnitOfMeasure\n"),
+		}),
+		AzureStorageContainerName:    "test-no-aks",
+		AzureStorageAKSDataPrefix:    "cost-analysis/",
+		AzureStorageCostExportPrefix: "cost-management/",
+		AzureStorageResultFile:       "cost-analysis/result.csv",
+		SQLiteFilePath:               t.TempDir() + "/test.sqlite",
+		ExportDate:                   &date,
+		Timeout:                      time.Minute,
+	}
+	app, err := NewApp(cfg)
+	require.NoError(t, err)
+	err = app.Merge(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no AKS export files")
+}
+
+func TestApp_Merge_EmptyAKSExport(t *testing.T) {
+	date := time.Date(2025, 6, 18, 0, 0, 0, 0, time.UTC)
+	cfg := Config{
+		AzureStorageConnectionString: SetupAzuriteContainer(t, "test-empty-aks", map[string][]byte{
+			"cost-analysis/export-2025-06-18.csv": []byte(""),
+			"cost-management/file1.csv":           []byte("SubscriptionGuid,ResourceGroup,ResourceLocation,UsageDateTime,MeterCategory,MeterSubCategory,MeterId,MeterName,MeterRegion,UsageQuantity,ResourceRate,PreTaxCost,ConsumedService,ResourceType,InstanceId,Tags,OfferId,AdditionalInfo,ServiceInfo1,ServiceInfo2,ServiceName,ServiceTier,Currency,UnitOfMeasure\n"),
+		}),
+		AzureStorageContainerName:    "test-empty-aks",
+		AzureStorageAKSDataPrefix:    "cost-analysis/",
+		AzureStorageCostExportPrefix: "cost-management/",
+		AzureStorageResultFile:       "cost-analysis/result.csv",
+		SQLiteFilePath:               t.TempDir() + "/test.sqlite",
+		ExportDate:                   &date,
+		Timeout:                      time.Minute,
+	}
+	app, err := NewApp(cfg)
+	require.NoError(t, err)
+	err = app.Merge(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no AKS export files")
+}
+
+func TestApp_Merge_NoCostManagementFiles(t *testing.T) {
+	date := time.Date(2025, 6, 18, 0, 0, 0, 0, time.UTC)
+	cfg := Config{
+		AzureStorageConnectionString: SetupAzuriteContainer(t, "test-no-cost", map[string][]byte{
+			"cost-analysis/export-2025-06-18.csv": []byte("Date,ID,Name,Kind,Fraction,SplitBucket,SplitKey\n2025-06-18,/subscriptions/test/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss,vmss,compute,1,usage,{}\n"),
+		}),
+		AzureStorageContainerName:    "test-no-cost",
+		AzureStorageAKSDataPrefix:    "cost-analysis/",
+		AzureStorageCostExportPrefix: "cost-management/",
+		AzureStorageResultFile:       "cost-analysis/result.csv",
+		SQLiteFilePath:               t.TempDir() + "/test.sqlite",
+		ExportDate:                   &date,
+		Timeout:                      time.Minute,
+	}
+	app, err := NewApp(cfg)
+	require.NoError(t, err)
+	err = app.Merge(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no cost management files")
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	path := t.TempDir() + "/importcsv.db"
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Ping())
+	return db
 }
 
 func TestConfig_Validate(t *testing.T) {


### PR DESCRIPTION
Follow-up to #5771. Fail the cost-analysis-export merge when AKS or Cost Management imports produce no usable rows, instead of logging an error and uploading a join of empty or missing tables.

## Problem

`Merge` always continues after import. Two cases look like success in logs and then fail later (or write a bad result):

1. **Zero matching blobs.** `importAKSData` and `importCostManagementData` log `no ... files found` and still `return nil`. Join then errors with `no such table: aks_splits` or `no resource ID column found`.
2. **Empty AKS CSV.** `ImportCSV` treats EOF on `aks_splits` as success without creating a table, increments `filesProcessed`, and join fails the same way. Empty Cost Management files still create the standard EA header table (unchanged).

This shipped in [#5393](https://github.com/Azure/AKS/pull/5393) (2025-10-24).

## Change

- Return an error from `importAKSData` / `importCostManagementData` when `filesProcessed == 0`.
- Return `empty CSV for table aks_splits` from `ImportCSV` on EOF (Cost Management empty-file table create is unchanged).
- Tests: unit coverage for empty `ImportCSV`, plus Azurite `Merge` cases for no AKS files, empty AKS export, and no cost files.

## Validation

```
Red:  go test -run TestImportCSV_EmptyAKSSplitsReturnsError
      FAIL: An error is expected but got nil
      TestApp_Merge_NoAKSExportFiles FAIL: join error does not contain "no AKS export files"
Green: go test -count=1 .
      ok  github.com/Azure/aks-cost-analysis-export
```

gofmt and `go vet` are clean.

## Related

- [#5771](https://github.com/Azure/AKS/pull/5771) applied `EXPORT_TIMEOUT` and closed the join temp file
- [#5393](https://github.com/Azure/AKS/pull/5393) added this example
