### PR TITLE
examples: Pin privileged nsenter DaemonSets to MCR alpine

### DIFF
--- a/examples/kubelet/enable-anonymous-auth-for-non-rbac.yaml
+++ b/examples/kubelet/enable-anonymous-auth-for-non-rbac.yaml
@@ -20,7 +20,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
         - name: nsenter
-          image: alpine
+          image: mcr.microsoft.com/azure-policy/alpine:prod_20200505.1
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/examples/kubelet/kubelet-parameters-ds.yaml
+++ b/examples/kubelet/kubelet-parameters-ds.yaml
@@ -50,7 +50,7 @@ spec:
              echo "kube-api-burst parameter has been added to kubelet configuration"
           fi
           while true; do sleep 100000; done
-        image: alpine
+        image: mcr.microsoft.com/azure-policy/alpine:prod_20200505.1
         imagePullPolicy: IfNotPresent
         name: kubelet-parameters
         resources:

--- a/examples/runc/downgraderunc.yaml
+++ b/examples/runc/downgraderunc.yaml
@@ -20,7 +20,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
         - name: nsenter
-          image: alpine
+          image: mcr.microsoft.com/azure-policy/alpine:prod_20200505.1
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true


### PR DESCRIPTION
Pin the three privileged host-nsenter DaemonSets to the same MCR Alpine image the other remediations in this repo already use.

## Problem

These examples run `privileged: true` with `hostPID` / `hostNetwork` and pull unpinned `image: alpine` (implicit latest) with `IfNotPresent`:

- `examples/kubelet/enable-anonymous-auth-for-non-rbac.yaml`
- `examples/kubelet/kubelet-parameters-ds.yaml`
- `examples/runc/downgraderunc.yaml`

A first pull of `alpine:latest` becomes whatever Docker Hub served that day, then stays cached. Sibling remediations already pin `mcr.microsoft.com/azure-policy/alpine:prod_20200505.1` (`disable-azsecd.yaml`, `iptables/snat_exemption_ds.yaml`, `unattended-upgrades/daemonset.yaml`).

Present since the original manifests ([`9d0e5f607`](https://github.com/Azure/AKS/commit/9d0e5f607) 2021-05-06, [`b4c5e6c9d`](https://github.com/Azure/AKS/commit/b4c5e6c9d) 2021-03-30).

## Change

Replace `image: alpine` with `mcr.microsoft.com/azure-policy/alpine:prod_20200505.1` in those three files only. Commands and security context are unchanged.

## Validation

Mechanical pin to an existing in-repo image. No example test harness for these YAML files. Confirmed with `rg` that the three files no longer use `image: alpine` and match the sibling tag.

## Related

- Same image in `examples/disable-azsecd.yaml`
