### PR TITLE
kernel-1095: Harden remediate.sh with pipefail and drain timeout

### DIFF
--- a/examples/kernel-1095-issue/remediate.sh
+++ b/examples/kernel-1095-issue/remediate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 # Please Add
 # Your AKS Cluster Subscription:
@@ -11,54 +11,60 @@ rg="<YOUR-RESOURCE-GROUP-NAME>"
 cn="<YOUR-AKS-CLUSTER-NAME>"
 
 # Set AKS kubectl creds
-az account set --subscription $sub
-az aks get-credentials --resource-group $rg --name $cn
+az account set --subscription "$sub"
+az aks get-credentials --resource-group "$rg" --name "$cn"
 
-mcrg=$(az aks show --name $cn --resource-group $rg --query "nodeResourceGroup" -o tsv)
+mcrg=$(az aks show --name "$cn" --resource-group "$rg" --query "nodeResourceGroup" -o tsv)
 echo "MC RG $mcrg"
 
 # Check each nodepool individually
-for np in $(az aks nodepool list --cluster-name $cn --resource-group $rg --query "[].name" -o tsv)
+for np in $(az aks nodepool list --cluster-name "$cn" --resource-group "$rg" --query "[].name" -o tsv)
 do
     echo "Going to cleanup for node pool $np"
-    # find total nodes
-    totalNodes=$(kubectl get nodes -l kubernetes.azure.com/agentpool=$np -o wide | grep $np | wc -l)
+    # Count Ready/NotReady nodes without grep|wc so a missed grep cannot
+    # become totalNodes=0 and scale the pool to 1.
+    totalNodes=$(kubectl get nodes -l "kubernetes.azure.com/agentpool=${np}" --no-headers | wc -l | tr -d ' ')
     echo "Total nodes of node pool $np is $totalNodes"
-    nodeList=$(kubectl get nodes -l kubernetes.azure.com/agentpool=$np -o wide | grep "5.4.0-1095-azure" | awk '{print $1}')
+    if [ "$totalNodes" -eq 0 ]; then
+        echo "No nodes found for node pool $np, skipping"
+        continue
+    fi
+    nodeList=$(kubectl get nodes -l "kubernetes.azure.com/agentpool=${np}" -o wide --no-headers | awk '/5.4.0-1095-azure/ {print $1}')
     echo "node list: $nodeList"
 
-    autoScalerEnabled=$(az aks nodepool show --cluster-name $cn --resource-group $rg --name $np --query "enableAutoScaling" -o tsv)
+    autoScalerEnabled=$(az aks nodepool show --cluster-name "$cn" --resource-group "$rg" --name "$np" --query "enableAutoScaling" -o tsv)
     echo "auto-scaler enabled: $autoScalerEnabled"
 
     if [ "$autoScalerEnabled" != "true" ]; then
         echo "Scale cluster by 1 node for removal of bad node"
-        az aks scale --resource-group $rg --name $cn --node-count $((totalNodes+1)) --nodepool-name $np
+        az aks scale --resource-group "$rg" --name "$cn" --node-count $((totalNodes+1)) --nodepool-name "$np"
     fi
 
     # Clean up each node with bad kernel
     for ns in $nodeList
     do
         echo "Going to cleanup for node $ns"
-    
+
         echo "Cordoning $ns"
-        kubectl cordon $ns
-    
+        kubectl cordon "$ns"
+
         echo "Draining $ns"
-        kubectl drain $ns --ignore-daemonsets --delete-emptydir-data
-    
-        vmssName=$(kubectl get node $ns -o yaml | grep "providerID" | awk -F '/' '{print $(NF-2)}')
-        instanceId=$(kubectl get node $ns -o yaml | grep "providerID" | awk -F '/' '{print $NF}')
+        kubectl drain "$ns" --ignore-daemonsets --delete-emptydir-data --timeout=5m
+
+        providerID=$(kubectl get node "$ns" -o jsonpath='{.spec.providerID}')
+        vmssName=$(awk -F '/' '{print $(NF-2)}' <<<"$providerID")
+        instanceId=$(awk -F '/' '{print $NF}' <<<"$providerID")
         echo "Re-image $vmssName/$instanceId"
-        az vmss reimage --instance-id $instanceId --name $vmssName --resource-group $mcrg
-    
+        az vmss reimage --instance-id "$instanceId" --name "$vmssName" --resource-group "$mcrg"
+
         echo "Uncordoning $ns"
-        kubectl uncordon $ns
-    
+        kubectl uncordon "$ns"
+
         echo "Cleanup for $ns ($vmssName/$instanceId) done"
     done
 
     if [ "$autoScalerEnabled" != "true" ]; then
         echo "Scale cluster to $totalNodes nodes"
-        az aks scale --resource-group $rg --name $cn --node-count $totalNodes --nodepool-name $np
+        az aks scale --resource-group "$rg" --name "$cn" --node-count "$totalNodes" --nodepool-name "$np"
     fi
 done

--- a/examples/kernel-1095-issue/remediate.sh
+++ b/examples/kernel-1095-issue/remediate.sh
@@ -31,6 +31,10 @@ do
     fi
     nodeList=$(kubectl get nodes -l "kubernetes.azure.com/agentpool=${np}" -o wide --no-headers | awk '/5.4.0-1095-azure/ {print $1}')
     echo "node list: $nodeList"
+    if [ -z "$nodeList" ]; then
+        echo "No kernel-1095 nodes in node pool $np, skipping"
+        continue
+    fi
 
     autoScalerEnabled=$(az aks nodepool show --cluster-name "$cn" --resource-group "$rg" --name "$np" --query "enableAutoScaling" -o tsv)
     echo "auto-scaler enabled: $autoScalerEnabled"

--- a/examples/kernel-1095-issue/remediate.sh
+++ b/examples/kernel-1095-issue/remediate.sh
@@ -21,8 +21,8 @@ echo "MC RG $mcrg"
 for np in $(az aks nodepool list --cluster-name "$cn" --resource-group "$rg" --query "[].name" -o tsv)
 do
     echo "Going to cleanup for node pool $np"
-    # Count Ready/NotReady nodes without grep|wc so a missed grep cannot
-    # become totalNodes=0 and scale the pool to 1.
+    # Count nodes with wc only. A missed grep cannot become totalNodes=0
+    # and scale the pool to 1. kubectl failure still fails the pipeline.
     totalNodes=$(kubectl get nodes -l "kubernetes.azure.com/agentpool=${np}" --no-headers | wc -l | tr -d ' ')
     echo "Total nodes of node pool $np is $totalNodes"
     if [ "$totalNodes" -eq 0 ]; then
@@ -47,6 +47,8 @@ do
 
         echo "Cordoning $ns"
         kubectl cordon "$ns"
+        # Drain timeout or reimage failure must not leave the node unschedulable.
+        trap 'kubectl uncordon "$ns" || true' EXIT
 
         echo "Draining $ns"
         kubectl drain "$ns" --ignore-daemonsets --delete-emptydir-data --timeout=5m
@@ -59,6 +61,7 @@ do
 
         echo "Uncordoning $ns"
         kubectl uncordon "$ns"
+        trap - EXIT
 
         echo "Cleanup for $ns ($vmssName/$instanceId) done"
     done


### PR DESCRIPTION
Harden `examples/kernel-1095-issue/remediate.sh` so a failed node count cannot scale the pool to 1, and so `kubectl drain` cannot block reimage forever.

## Problem

The script is still the documented remediation for kernel `5.4.0-1095-azure` ([#3350](https://github.com/Azure/AKS/pull/3350), 2022-11-19). Two issues:

1. **Missing `pipefail`.** `totalNodes=$(kubectl get nodes ... | grep $np | wc -l)` succeeds with `0` if `kubectl` or `grep` fails, because `wc -l` exits 0. The script then runs `az aks scale --node-count $((0+1))`.
2. **Infinite drain.** `kubectl drain` defaults `--timeout` to 0. A PDB or stuck pod blocks `az vmss reimage` indefinitely.

Repo Copilot instructions require `set -euo pipefail` for shell scripts.

## Change

- `set -euo pipefail`
- Count nodes with `kubectl get nodes --no-headers | wc -l` (no `grep` in that pipeline)
- Skip the pool when `totalNodes` is 0
- List bad kernels with `awk` so a no-match is empty, not a failed pipeline
- `kubectl drain ... --timeout=5m`
- Read `providerID` with `jsonpath` so a missed `grep` cannot abort after drain (node left cordoned)
- Quote Azure and kubectl arguments

## Validation

`shellcheck examples/kernel-1095-issue/remediate.sh` is clean. This repo has no bash test suite for the script. I did not run it against a live cluster.

## Related

- [#3350](https://github.com/Azure/AKS/pull/3350) added the script
- [kubectl drain `--timeout`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_drain/)
